### PR TITLE
NON-10: Optional assigned living unit fields

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,38 +63,38 @@ workflows:
             - build_docker
             - helm_lint
           helm_timeout: 5m
-#      - request-preprod-approval:
-#          type: approval
-#          requires:
-#            - deploy_dev
-#      - hmpps/deploy_env:
-#          name: deploy_preprod
-#          env: "preprod"
-#          jira_update: true
-#          jira_env_type: staging
-#          context:
-#            - hmpps-common-vars
-#            - hmpps-non-associations-api-preprod
-#          requires:
-#            - request-preprod-approval
-#          helm_timeout: 5m
-#      - request-prod-approval:
-#          type: approval
-#          requires:
-#            - deploy_preprod
-#      - hmpps/deploy_env:
-#          name: deploy_prod
-#          env: "prod"
-#          jira_update: true
-#          jira_env_type: production
-#          slack_notification: true
-#          slack_channel_name: << pipeline.parameters.releases-slack-channel >>
-#          context:
-#            - hmpps-common-vars
-#            - hmpps-non-associations-api-prod
-#          requires:
-#            - request-prod-approval
-#          helm_timeout: 5m
+      - request-preprod-approval:
+          type: approval
+          requires:
+            - deploy_dev
+      - hmpps/deploy_env:
+          name: deploy_preprod
+          env: "preprod"
+          jira_update: true
+          jira_env_type: staging
+          context:
+            - hmpps-common-vars
+            - hmpps-non-associations-api-preprod
+          requires:
+            - request-preprod-approval
+          helm_timeout: 5m
+      - request-prod-approval:
+          type: approval
+          requires:
+            - deploy_preprod
+      - hmpps/deploy_env:
+          name: deploy_prod
+          env: "prod"
+          jira_update: true
+          jira_env_type: production
+          slack_notification: true
+          slack_channel_name: << pipeline.parameters.releases-slack-channel >>
+          context:
+            - hmpps-common-vars
+            - hmpps-non-associations-api-prod
+          requires:
+            - request-prod-approval
+          helm_timeout: 5m
 
   security:
     triggers:

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/dto/prisonapi/NonAssociationDetails.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/dto/prisonapi/NonAssociationDetails.kt
@@ -15,10 +15,10 @@ data class NonAssociationDetails(
   val lastName: String,
   @Schema(description = "Description of the agency (e.g. prison) the offender is assigned to", required = true, example = "Moorland (HMP & YOI)")
   val agencyDescription: String,
-  @Schema(description = "Description of living unit (e.g. cell) the offender is assigned to.", required = true, example = "MDI-1-1-3")
-  val assignedLivingUnitDescription: String,
-  @Schema(description = "ID of living unit (e.g. cell) the offender is assigned to.", required = true, example = "113")
-  val assignedLivingUnitId: Long,
+  @Schema(description = "Description of living unit (e.g. cell) the offender is assigned to.", required = false, example = "MDI-1-1-3")
+  val assignedLivingUnitDescription: String?,
+  @Schema(description = "ID of living unit (e.g. cell) the offender is assigned to.", required = false, example = "113")
+  val assignedLivingUnitId: Long? = null,
   @Schema(description = "Non-associations with other prisoners", required = true)
   val nonAssociations: List<NonAssociation>,
 )
@@ -63,8 +63,8 @@ data class OffenderNonAssociation(
   val reasonDescription: String,
   @Schema(description = "Description of the agency (e.g. prison) the offender is assigned to", required = true, example = "Moorland (HMP & YOI)")
   val agencyDescription: String,
-  @Schema(description = "Description of living unit (e.g. cell) the offender is assigned to.", required = true, example = "MDI-2-3-4")
-  val assignedLivingUnitDescription: String,
-  @Schema(description = "ID of living unit (e.g. cell) the offender is assigned to.", required = true, example = "234")
-  val assignedLivingUnitId: Long,
+  @Schema(description = "Description of living unit (e.g. cell) the offender is assigned to.", required = false, example = "MDI-2-3-4")
+  val assignedLivingUnitDescription: String?,
+  @Schema(description = "ID of living unit (e.g. cell) the offender is assigned to.", required = false, example = "234")
+  val assignedLivingUnitId: Long? = null,
 )


### PR DESCRIPTION
The assigned living unit fields could be null and in general a non-association could be with someone who left prison (but may return, and that's why it's imporant to still retain the non-association)

I've also update the Swagger documentation for the fields accordingly.

**NOTE**: While I was getting an exception when Spring Boot/Jackson for the missing mandatory `String` field, it didn't complain about the missing `Long` field and implicitly converted it to `0`.

We should distinguish between `0`s and `null`s are these are different concept, one signifify the absence of information (e.g. there is no assigned unit) while the other imply knowledge (e.g. the assigned unit is XYZ). We don't want `0` to be possibly interpreted as an ID for a real living unit as that would be wrong.

That's why the `Long?` optional fields have a default value of `null` now.

PS: I've updated the CircleCI config to allow deployment to `preprod`/`prod` now.