### PR TITLE
NON-10: Skeleton of new non-associations endpoint

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/config/HmppsNonAssociationsApiExceptionHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/config/HmppsNonAssociationsApiExceptionHandler.kt
@@ -6,6 +6,7 @@ import org.springframework.http.HttpStatus
 import org.springframework.http.HttpStatus.BAD_REQUEST
 import org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR
 import org.springframework.http.ResponseEntity
+import org.springframework.security.access.AccessDeniedException
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.RestControllerAdvice
 import org.springframework.web.reactive.function.client.WebClientResponseException.NotFound
@@ -21,6 +22,20 @@ class HmppsNonAssociationsApiExceptionHandler {
         ErrorResponse(
           status = BAD_REQUEST,
           userMessage = "Validation failure: ${e.message}",
+          developerMessage = e.message,
+        ),
+      )
+  }
+
+  @ExceptionHandler(AccessDeniedException::class)
+  fun handleAccessDeniedException(e: AccessDeniedException): ResponseEntity<ErrorResponse> {
+    log.debug("Forbidden (403) returned with message {}", e.message)
+    return ResponseEntity
+      .status(HttpStatus.FORBIDDEN)
+      .body(
+        ErrorResponse(
+          status = HttpStatus.FORBIDDEN,
+          userMessage = "Forbidden: ${e.message}",
           developerMessage = e.message,
         ),
       )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/dto/NonAssociationDetails.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/dto/NonAssociationDetails.kt
@@ -1,0 +1,15 @@
+package uk.gov.justice.digital.hmpps.hmppsnonassociationsapi.dto
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+/**
+ * Non-association details
+ *
+ * TODO: This is WIP at the moment. It may share some similarities with the
+ * format currently returned by NOMIS/Prison API but it's a distinct type
+ * and will likely differ.
+ */
+data class NonAssociationDetails(
+  @Schema(description = "Prisoner number", required = true, example = "A1234BC")
+  val prisonerNumber: String,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/dto/prisonapi/LegacyNonAssociationDetails.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/dto/prisonapi/LegacyNonAssociationDetails.kt
@@ -6,7 +6,7 @@ import java.time.LocalDateTime
 /**
  * Top-level type for non-association details returned by Prison API
  */
-data class NonAssociationDetails(
+data class LegacyNonAssociationDetails(
   @Schema(description = "Prisoner number", required = true, example = "A1234BC")
   val offenderNo: String,
   @Schema(description = "First name", required = true, example = "James")
@@ -20,13 +20,13 @@ data class NonAssociationDetails(
   @Schema(description = "ID of living unit (e.g. cell) the offender is assigned to.", required = false, example = "113")
   val assignedLivingUnitId: Long? = null,
   @Schema(description = "Non-associations with other prisoners", required = true)
-  val nonAssociations: List<NonAssociation>,
+  val nonAssociations: List<LegacyNonAssociation>,
 )
 
 /**
  * Prison API format for a single non-association
  */
-data class NonAssociation(
+data class LegacyNonAssociation(
   @Schema(description = "Reason code for the non-association", required = true, example = "VIC")
   val reasonCode: String,
   @Schema(description = "Reason for the non-association", required = true, example = "Victim")
@@ -44,13 +44,13 @@ data class NonAssociation(
   @Schema(description = "Additional free text comments related to the non-association.", required = false, example = "Mr. Bloggs assaulted Mr. Hall")
   val comments: String?,
   @Schema(description = "Details about the other non-association person.", required = true)
-  val offenderNonAssociation: OffenderNonAssociation,
+  val offenderNonAssociation: LegacyOffenderNonAssociation,
 )
 
 /**
  * Prison API format containing the details of the other side of the non-association relation
  */
-data class OffenderNonAssociation(
+data class LegacyOffenderNonAssociation(
   @Schema(description = "Prisoner number", required = true, example = "B1234CD")
   val offenderNo: String,
   @Schema(description = "First name", required = true, example = "Joseph")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/jpa/ReasonType.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/jpa/ReasonType.kt
@@ -19,6 +19,4 @@ data class ReasonType(
   val whenCreated: LocalDateTime = LocalDateTime.now(),
   @LastModifiedDate
   val whenUpdated: LocalDateTime = LocalDateTime.now(),
-) {
-  constructor() : this("", "")
-}
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/jpa/ReasonType.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/jpa/ReasonType.kt
@@ -18,5 +18,5 @@ data class ReasonType(
   @CreatedDate
   val whenCreated: LocalDateTime = LocalDateTime.now(),
   @LastModifiedDate
-  val whenUpdated: LocalDateTime = LocalDateTime.now(),
+  var whenUpdated: LocalDateTime = LocalDateTime.now(),
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/resource/NonAssociationsResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/resource/NonAssociationsResource.kt
@@ -1,0 +1,60 @@
+package uk.gov.justice.digital.hmpps.hmppsnonassociationsapi.resource
+
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
+import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.validation.annotation.Validated
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.ResponseStatus
+import org.springframework.web.bind.annotation.RestController
+import uk.gov.justice.digital.hmpps.hmppsnonassociationsapi.config.ErrorResponse
+import uk.gov.justice.digital.hmpps.hmppsnonassociationsapi.dto.NonAssociationDetails
+
+@RestController
+@Validated
+@RequestMapping("/", produces = [MediaType.APPLICATION_JSON_VALUE])
+@Tag(name = "Non-Associations", description = "Retrieve non-associations")
+class NonAssociationsResource() {
+  @GetMapping("/prisoner/{prisonerNumber}/non-associations")
+  @PreAuthorize("hasRole('ROLE_NON_ASSOCIATIONS')")
+  @ResponseStatus(HttpStatus.OK)
+  @Operation(
+    summary = "**IMPORTANT**: This is a work in progress API and it's subject to change, DO NOT USE. Get non-associations by prisoner number. Requires ROLE_NON_ASSOCIATIONS role.",
+    description = "The offender prisoner number",
+    responses = [
+      ApiResponse(
+        responseCode = "200",
+        description = "Returns non-association details for this prisoner",
+      ),
+      ApiResponse(
+        responseCode = "401",
+        description = "Unauthorized to access this endpoint",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+      ApiResponse(
+        responseCode = "403",
+        description = "Missing required role. Requires the NON_ASSOCIATIONS role",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+      ApiResponse(
+        responseCode = "404",
+        description = "Prisoner number not found",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+    ],
+  )
+  fun getDetailsByPrisonerNumber(
+    @Schema(description = "The offender prisoner number", example = "A1234BC", required = true)
+    @PathVariable
+    prisonerNumber: String,
+  ): NonAssociationDetails {
+    return NonAssociationDetails(prisonerNumber)
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/resource/PrisonApiResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/resource/PrisonApiResource.kt
@@ -48,7 +48,7 @@ class PrisonApiResource(
       ),
     ],
   )
-  fun getDetailsByPrisonerNumber(
+  fun getDetailsFromPrisonApiByPrisonerNumber(
     @Schema(description = "The offender prisoner number", example = "A1234BC", required = true)
     @PathVariable
     prisonerNumber: String,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/resource/PrisonApiResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/resource/PrisonApiResource.kt
@@ -15,7 +15,7 @@ import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
 import uk.gov.justice.digital.hmpps.hmppsnonassociationsapi.config.ErrorResponse
-import uk.gov.justice.digital.hmpps.hmppsnonassociationsapi.dto.prisonapi.NonAssociationDetails
+import uk.gov.justice.digital.hmpps.hmppsnonassociationsapi.dto.prisonapi.LegacyNonAssociationDetails
 import uk.gov.justice.digital.hmpps.hmppsnonassociationsapi.service.NonAssociationsService
 
 @RestController
@@ -52,7 +52,7 @@ class PrisonApiResource(
     @Schema(description = "The offender prisoner number", example = "A1234BC", required = true)
     @PathVariable
     prisonerNumber: String,
-  ): NonAssociationDetails {
+  ): LegacyNonAssociationDetails {
     return nonAssociationsService.getDetails(prisonerNumber)
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/resource/PrisonApiResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/resource/PrisonApiResource.kt
@@ -7,7 +7,6 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
-import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.validation.annotation.Validated
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
@@ -26,7 +25,6 @@ class PrisonApiResource(
   val nonAssociationsService: NonAssociationsService,
 ) {
   @GetMapping("/offenders/{prisonerNumber}/non-association-details")
-  @PreAuthorize("hasRole('ROLE_NON_ASSOCIATIONS')")
   @ResponseStatus(HttpStatus.OK)
   @Operation(
     summary = "Get non-associations by Prisoner number",

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/resource/PrisonApiResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/resource/PrisonApiResource.kt
@@ -21,7 +21,7 @@ import uk.gov.justice.digital.hmpps.hmppsnonassociationsapi.service.NonAssociati
 @RestController
 @Validated
 @RequestMapping("/legacy/api", produces = [MediaType.APPLICATION_JSON_VALUE])
-@Tag(name = "Non-Associations", description = "Retrieve non association details from prison-api")
+@Tag(name = "Legacy non-associations-details", description = "Retrieve non association details from Prison API")
 class PrisonApiResource(
   val nonAssociationsService: NonAssociationsService,
 ) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/service/NonAssociationsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/service/NonAssociationsService.kt
@@ -1,14 +1,14 @@
 package uk.gov.justice.digital.hmpps.hmppsnonassociationsapi.service
 
 import org.springframework.stereotype.Service
-import uk.gov.justice.digital.hmpps.hmppsnonassociationsapi.dto.prisonapi.NonAssociationDetails
+import uk.gov.justice.digital.hmpps.hmppsnonassociationsapi.dto.prisonapi.LegacyNonAssociationDetails
 
 @Service
 class NonAssociationsService(
   private val prisonApiService: PrisonApiService,
 ) {
 
-  fun getDetails(prisonerNumber: String): NonAssociationDetails {
+  fun getDetails(prisonerNumber: String): LegacyNonAssociationDetails {
     return prisonApiService.getNonAssociationDetails(prisonerNumber)
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/service/PrisonApiService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/service/PrisonApiService.kt
@@ -1,9 +1,8 @@
 package uk.gov.justice.digital.hmpps.hmppsnonassociationsapi.service
 
-import org.springframework.core.ParameterizedTypeReference
 import org.springframework.stereotype.Service
 import org.springframework.web.reactive.function.client.WebClient
-import uk.gov.justice.digital.hmpps.hmppsnonassociationsapi.dto.prisonapi.NonAssociationDetails
+import uk.gov.justice.digital.hmpps.hmppsnonassociationsapi.dto.prisonapi.LegacyNonAssociationDetails
 
 @Service
 class PrisonApiService(
@@ -15,12 +14,12 @@ class PrisonApiService(
     return if (useClientCredentials) prisonWebClientClientCredentials else prisonWebClient
   }
 
-  fun getNonAssociationDetails(prisonerNumber: String, useClientCredentials: Boolean = false): NonAssociationDetails {
+  fun getNonAssociationDetails(prisonerNumber: String, useClientCredentials: Boolean = false): LegacyNonAssociationDetails {
     return getClient(useClientCredentials)
       .get()
       .uri("/api/offenders/$prisonerNumber/non-association-details")
       .retrieve()
-      .bodyToMono(object : ParameterizedTypeReference<NonAssociationDetails>() {})
+      .bodyToMono(LegacyNonAssociationDetails::class.java)
       .block()!!
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/integration/wiremock/PrisonApiMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/integration/wiremock/PrisonApiMockServer.kt
@@ -5,7 +5,7 @@ import com.github.tomakehurst.wiremock.WireMockServer
 import com.github.tomakehurst.wiremock.client.WireMock
 import com.github.tomakehurst.wiremock.client.WireMock.aResponse
 import com.github.tomakehurst.wiremock.client.WireMock.get
-import uk.gov.justice.digital.hmpps.hmppsnonassociationsapi.dto.prisonapi.NonAssociationDetails
+import uk.gov.justice.digital.hmpps.hmppsnonassociationsapi.dto.prisonapi.LegacyNonAssociationDetails
 
 class PrisonApiMockServer : WireMockServer(WIREMOCK_PORT) {
   companion object {
@@ -16,7 +16,7 @@ class PrisonApiMockServer : WireMockServer(WIREMOCK_PORT) {
 
   fun getCountFor(url: String) = this.findAll(WireMock.getRequestedFor(WireMock.urlEqualTo(url))).count()
 
-  fun stubGetNonAssociationDetailsByPrisonerNumber(nonAssociationDetails: NonAssociationDetails) {
+  fun stubGetNonAssociationDetailsByPrisonerNumber(nonAssociationDetails: LegacyNonAssociationDetails) {
     stubFor(
       get("/api/offenders/${nonAssociationDetails.offenderNo}/non-association-details").willReturn(
         aResponse()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/jpa/repository/ReasonTypeRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/jpa/repository/ReasonTypeRepositoryTest.kt
@@ -43,6 +43,9 @@ class ReasonTypeRepositoryTest : TestBase() {
   fun updateRecord() {
     val reason = repository.findById("VIC").orElseThrow { Exception("ReasonType not found") }
     val whenCreated = reason.whenCreated
+    val whenUpdated = reason.whenUpdated
+
+    // Update the record
     repository.save(reason.copy(description = "UPDATED"))
 
     TestTransaction.flagForCommit()
@@ -52,5 +55,7 @@ class ReasonTypeRepositoryTest : TestBase() {
     val reasonUpdated = repository.findById("VIC").orElseThrow { Exception("ReasonType not found") }
     assertThat(reasonUpdated.description).isEqualTo("UPDATED")
     assertThat(reasonUpdated.whenCreated).isEqualTo(whenCreated)
+    // whenUpdated has changed
+    assertThat(reasonUpdated.whenUpdated).isAfter(whenUpdated)
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/resource/NonAssociationsResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/resource/NonAssociationsResourceTest.kt
@@ -1,0 +1,49 @@
+package uk.gov.justice.digital.hmpps.hmppsnonassociationsapi.resource
+
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.hmppsnonassociationsapi.integration.IntegrationTestBase
+
+class NonAssociationsResourceTest : IntegrationTestBase() {
+
+  final val prisonerNumber = "A1234BC"
+
+  @Nested
+  inner class `GET non associations for a prisoner` {
+
+    private val url = "/prisoner/$prisonerNumber/non-associations"
+
+    @Test
+    fun `without a valid token responds 401 Unauthorized`() {
+      webTestClient.get()
+        .uri(url)
+        .exchange()
+        .expectStatus()
+        .isUnauthorized
+    }
+
+    @Test
+    fun `without the correct role responds 403 Forbidden`() {
+      webTestClient.get()
+        .uri(url)
+        .headers(setAuthorisation(roles = listOf("WRONG_ROLE")))
+        .exchange()
+        .expectStatus()
+        .isForbidden
+    }
+
+    @Test
+    fun `with a valid token returns the non-association details`() {
+      val expectedResponse = jsonString(mapOf("prisonerNumber" to prisonerNumber))
+      webTestClient.get()
+        .uri(url)
+        .headers(setAuthorisation(roles = listOf("ROLE_NON_ASSOCIATIONS")))
+        .exchange()
+        .expectStatus().isOk
+        .expectBody().json(
+          expectedResponse,
+          true,
+        )
+    }
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/resource/PrisonApiResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/resource/PrisonApiResourceTest.kt
@@ -3,9 +3,9 @@ package uk.gov.justice.digital.hmpps.hmppsnonassociationsapi.resource
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
-import uk.gov.justice.digital.hmpps.hmppsnonassociationsapi.dto.prisonapi.NonAssociation
-import uk.gov.justice.digital.hmpps.hmppsnonassociationsapi.dto.prisonapi.NonAssociationDetails
-import uk.gov.justice.digital.hmpps.hmppsnonassociationsapi.dto.prisonapi.OffenderNonAssociation
+import uk.gov.justice.digital.hmpps.hmppsnonassociationsapi.dto.prisonapi.LegacyNonAssociation
+import uk.gov.justice.digital.hmpps.hmppsnonassociationsapi.dto.prisonapi.LegacyNonAssociationDetails
+import uk.gov.justice.digital.hmpps.hmppsnonassociationsapi.dto.prisonapi.LegacyOffenderNonAssociation
 import uk.gov.justice.digital.hmpps.hmppsnonassociationsapi.integration.IntegrationTestBase
 import java.time.LocalDateTime
 
@@ -14,7 +14,7 @@ class PrisonApiResourceTest : IntegrationTestBase() {
   final val prisonerNumber = "A1234BC"
 
   val nonAssociationDetails =
-    NonAssociationDetails(
+    LegacyNonAssociationDetails(
       offenderNo = prisonerNumber,
       firstName = "James",
       lastName = "Hall",
@@ -22,7 +22,7 @@ class PrisonApiResourceTest : IntegrationTestBase() {
       assignedLivingUnitDescription = "MDI-1-1-3",
       assignedLivingUnitId = 113,
       nonAssociations = listOf(
-        NonAssociation(
+        LegacyNonAssociation(
           reasonCode = "VIC",
           reasonDescription = "Victim",
           typeCode = "WING",
@@ -31,7 +31,7 @@ class PrisonApiResourceTest : IntegrationTestBase() {
           expiryDate = LocalDateTime.parse("2021-07-05T10:35:17"),
           authorisedBy = "Officer Alice B.",
           comments = "Mr. Bloggs assaulted Mr. Hall",
-          offenderNonAssociation = OffenderNonAssociation(
+          offenderNonAssociation = LegacyOffenderNonAssociation(
             offenderNo = "B1234CD",
             firstName = "Joseph",
             lastName = "Bloggs",


### PR DESCRIPTION
- `GET /prisoner/{prisonerNumber}/non-associations`
- this is just a placeholder/starting point and very much subject to change (and this is made explicit in the Swagger docs)
- endpoint uses `ROLE_NON_ASSOCIATIONS` as discussed although authorisation may need further discussion
- the response format is just a stub at this stage (as design is still in flux and this may affect data model) - but the main point is that this format/dto class is different and separate from the one used by the legacy/Prison API endpoint
  - This is mainly to allow us design freedom, however those two formats will have to have some level of compatibility for synchronisation purposes obviously
- handling of `AccessDenied` exceptions so that the client gets an appropriate `403 Forbidden` rather than a `500 Internal Server Error`

Also, replaced `.bodyToMono(object : ParameterizedTypeReference<NonAssociationDetails>() {})` with `.bodyToMono(LegacyNonAssociationDetails::class.java)` as it seems to work the same (in this context at least) but reads better.