### PR TITLE
NON-86: `POST /non-associations` endpoint

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/config/HmppsNonAssociationsApiExceptionHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/config/HmppsNonAssociationsApiExceptionHandler.kt
@@ -8,6 +8,7 @@ import org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR
 import org.springframework.http.ResponseEntity
 import org.springframework.http.converter.HttpMessageNotReadableException
 import org.springframework.security.access.AccessDeniedException
+import org.springframework.web.HttpMediaTypeNotSupportedException
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.RestControllerAdvice
 import org.springframework.web.reactive.function.client.WebClientResponseException.NotFound
@@ -23,6 +24,20 @@ class HmppsNonAssociationsApiExceptionHandler {
         ErrorResponse(
           status = BAD_REQUEST,
           userMessage = "Validation failure: ${e.message}",
+          developerMessage = e.message,
+        ),
+      )
+  }
+
+  @ExceptionHandler(HttpMediaTypeNotSupportedException::class)
+  fun handleInvalidRequestFormatValidationException(e: Exception): ResponseEntity<ErrorResponse> {
+    log.info("Validation exception: Request format not supported: {}", e.message)
+    return ResponseEntity
+      .status(BAD_REQUEST)
+      .body(
+        ErrorResponse(
+          status = BAD_REQUEST,
+          userMessage = "Validation failure: Request format not supported: ${e.message}",
           developerMessage = e.message,
         ),
       )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/config/HmppsNonAssociationsApiExceptionHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/config/HmppsNonAssociationsApiExceptionHandler.kt
@@ -6,6 +6,7 @@ import org.springframework.http.HttpStatus
 import org.springframework.http.HttpStatus.BAD_REQUEST
 import org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR
 import org.springframework.http.ResponseEntity
+import org.springframework.http.converter.HttpMessageNotReadableException
 import org.springframework.security.access.AccessDeniedException
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.RestControllerAdvice
@@ -22,6 +23,20 @@ class HmppsNonAssociationsApiExceptionHandler {
         ErrorResponse(
           status = BAD_REQUEST,
           userMessage = "Validation failure: ${e.message}",
+          developerMessage = e.message,
+        ),
+      )
+  }
+
+  @ExceptionHandler(HttpMessageNotReadableException::class)
+  fun handleNoBodyValidationException(e: Exception): ResponseEntity<ErrorResponse> {
+    log.info("Validation exception: Couldn't read request body: {}", e.message)
+    return ResponseEntity
+      .status(BAD_REQUEST)
+      .body(
+        ErrorResponse(
+          status = BAD_REQUEST,
+          userMessage = "Validation failure: Couldn't read request body: ${e.message}",
           developerMessage = e.message,
         ),
       )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/dto/NonAssociation.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/dto/NonAssociation.kt
@@ -1,0 +1,57 @@
+package uk.gov.justice.digital.hmpps.hmppsnonassociationsapi.dto
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+/**
+ * Non-association between two prisoners
+ */
+data class NonAssociation(
+  @Schema(description = "ID of the non-association", required = false, example = "42")
+  val id: Long,
+
+  @Schema(description = "Prisoner number to not associate", required = true, example = "A1234BC")
+  val firstPrisonerNumber: String,
+  @Schema(description = "Reason why this prisoner should be kept apart from the other", required = true, example = "VICTIM")
+  val firstPrisonerReason: NonAssociationReason,
+  @Schema(description = "Prisoner number to not associate", required = true, example = "D5678EF")
+  val secondPrisonerNumber: String,
+  @Schema(description = "Reason why this prisoner should be kept apart from the other", required = true, example = "PERPETRATOR")
+  val secondPrisonerReason: NonAssociationReason,
+
+  @Schema(description = "Type of restriction, e.g. don't locate in the same cell", required = true, example = "CELL")
+  val restrictionType: NonAssociationRestrictionType,
+
+  @Schema(description = "Type of restriction, e.g. don't locate in the same cell", required = true, example = "John and Luke always end up fighting")
+  val comment: String,
+  @Schema(description = "User ID of the person who created the non-association. NOTE: For records migrated from NOMIS/Prison API this is free text and may not be a valid User ID", required = true, example = "OFF3_GEN")
+  val authorisedBy: String,
+
+  @Schema(description = "Whether the non-association is closed or is in effect", required = true, example = "false")
+  val isClosed: Boolean = false,
+  @Schema(description = "User ID of the person who closed the non-association. Only present when the non-association is closed, null for open non-associations", required = false, example = "null")
+  val closedBy: String? = null,
+  @Schema(description = "Reason why the non-association was closed. Only present when the non-association is closed, null for open non-associations", required = false, example = "null")
+  val closedReason: String? = null,
+  @Schema(description = "Date and time of when the non-association was closed. Only present when the non-association is closed, null for open non-associations", required = false, example = "null")
+  val closedAt: String? = null,
+)
+
+/**
+ * Request format for creating a new, open, non-association between two prisoners
+ */
+data class CreateNonAssociationRequest(
+  @Schema(description = "Prisoner number to not associate", required = true, example = "A1234BC")
+  val firstPrisonerNumber: String,
+  @Schema(description = "Reason why this prisoner should be kept apart from the other", required = true, example = "VICTIM")
+  val firstPrisonerReason: NonAssociationReason,
+  @Schema(description = "Prisoner number to not associate", required = true, example = "D5678EF")
+  val secondPrisonerNumber: String,
+  @Schema(description = "Reason why this prisoner should be kept apart from the other", required = true, example = "PERPETRATOR")
+  val secondPrisonerReason: NonAssociationReason,
+
+  @Schema(description = "Type of restriction, e.g. don't locate in the same cell", required = true, example = "CELL")
+  val restrictionType: NonAssociationRestrictionType,
+
+  @Schema(description = "Type of restriction, e.g. don't locate in the same cell", required = true, example = "John and Luke always end up fighting")
+  val comment: String,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/dto/NonAssociation.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/dto/NonAssociation.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.hmppsnonassociationsapi.dto
 
 import io.swagger.v3.oas.annotations.media.Schema
+import uk.gov.justice.digital.hmpps.hmppsnonassociationsapi.jpa.NonAssociation as NonAssociationJPA
 
 /**
  * Non-association between two prisoners
@@ -54,4 +55,17 @@ data class CreateNonAssociationRequest(
 
   @Schema(description = "Type of restriction, e.g. don't locate in the same cell", required = true, example = "John and Luke always end up fighting")
   val comment: String,
-)
+) {
+  fun toNewEntity(authorisedBy: String): NonAssociationJPA {
+    return NonAssociationJPA(
+      id = null,
+      firstPrisonerNumber = firstPrisonerNumber,
+      firstPrisonerReason = firstPrisonerReason,
+      secondPrisonerNumber = secondPrisonerNumber,
+      secondPrisonerReason = secondPrisonerReason,
+      restrictionType = restrictionType,
+      comment = comment,
+      authorisedBy = authorisedBy,
+    )
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/jpa/NonAssociation.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/jpa/NonAssociation.kt
@@ -14,6 +14,7 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener
 import uk.gov.justice.digital.hmpps.hmppsnonassociationsapi.dto.NonAssociationReason
 import uk.gov.justice.digital.hmpps.hmppsnonassociationsapi.dto.NonAssociationRestrictionType
 import java.time.LocalDateTime
+import uk.gov.justice.digital.hmpps.hmppsnonassociationsapi.dto.NonAssociation as NonAssociationDTO
 
 @Entity
 @EntityListeners(AuditingEntityListener::class)
@@ -56,5 +57,21 @@ class NonAssociation(
     this.closedBy = closedBy
     this.closedReason = closedReason
     this.closedAt = closedAt
+  }
+
+  fun toDto(): NonAssociationDTO {
+    return NonAssociationDTO(
+      id = id!!,
+      firstPrisonerNumber = firstPrisonerNumber,
+      firstPrisonerReason = firstPrisonerReason,
+      secondPrisonerNumber = secondPrisonerNumber,
+      secondPrisonerReason = secondPrisonerReason,
+      restrictionType = restrictionType,
+      comment = comment,
+      // TODO: Do we need to do anything special with this?
+      //       This field being optional in NOMIS/Prison API
+      //       It may be one of the things we make mandatory after migration?
+      authorisedBy = authorisedBy ?: "",
+    )
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/jpa/NonAssociation.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/jpa/NonAssociation.kt
@@ -36,7 +36,7 @@ class NonAssociation(
   @Enumerated(value = EnumType.STRING)
   @Column(name = "restriction_type_code")
   var restrictionType: NonAssociationRestrictionType,
-  var comment: String = "",
+  var comment: String,
   var authorisedBy: String? = null,
   var incidentReportNumber: String? = null,
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/jpa/repository/NonAssociationsRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/jpa/repository/NonAssociationsRepository.kt
@@ -5,4 +5,4 @@ import org.springframework.stereotype.Repository
 import uk.gov.justice.digital.hmpps.hmppsnonassociationsapi.jpa.NonAssociation
 
 @Repository
-interface NonAssociationRepository : JpaRepository<NonAssociation, Long>
+interface NonAssociationsRepository : JpaRepository<NonAssociation, Long>

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/service/NonAssociationsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/service/NonAssociationsService.kt
@@ -1,14 +1,65 @@
 package uk.gov.justice.digital.hmpps.hmppsnonassociationsapi.service
 
+import jakarta.transaction.Transactional
 import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.hmppsnonassociationsapi.config.AuthenticationFacade
+import uk.gov.justice.digital.hmpps.hmppsnonassociationsapi.dto.CreateNonAssociationRequest
 import uk.gov.justice.digital.hmpps.hmppsnonassociationsapi.dto.prisonapi.LegacyNonAssociationDetails
+import uk.gov.justice.digital.hmpps.hmppsnonassociationsapi.jpa.repository.NonAssociationsRepository
+import uk.gov.justice.digital.hmpps.hmppsnonassociationsapi.dto.NonAssociation as NonAssociationDTO
+import uk.gov.justice.digital.hmpps.hmppsnonassociationsapi.jpa.NonAssociation as NonAssociationJPA
 
 @Service
 class NonAssociationsService(
+  private val nonAssociationsRepository: NonAssociationsRepository,
+  private val authenticationFacade: AuthenticationFacade,
   private val prisonApiService: PrisonApiService,
 ) {
+
+  fun createNonAssociation(createNonAssociationRequest: CreateNonAssociationRequest): NonAssociationDTO {
+    val nonAssociationJpa = createNonAssociationRequest.toNewEntity(
+      authorisedBy = authenticationFacade.currentUsername ?: throw Exception("Could not determine current user's username'"),
+    )
+    return persistNonAssociation(nonAssociationJpa).also {
+      // TODO: Publish domain event (outside transaction)
+    }.toDto()
+  }
 
   fun getDetails(prisonerNumber: String): LegacyNonAssociationDetails {
     return prisonApiService.getNonAssociationDetails(prisonerNumber)
   }
+
+  @Transactional
+  private fun persistNonAssociation(nonAssociation: NonAssociationJPA): NonAssociationJPA {
+    return nonAssociationsRepository.save(nonAssociation)
+  }
+}
+
+private fun CreateNonAssociationRequest.toNewEntity(authorisedBy: String): NonAssociationJPA {
+  return NonAssociationJPA(
+    id = null,
+    firstPrisonerNumber = firstPrisonerNumber,
+    firstPrisonerReason = firstPrisonerReason,
+    secondPrisonerNumber = secondPrisonerNumber,
+    secondPrisonerReason = secondPrisonerReason,
+    restrictionType = restrictionType,
+    comment = comment,
+    authorisedBy = authorisedBy,
+  )
+}
+
+private fun NonAssociationJPA.toDto(): NonAssociationDTO {
+  return NonAssociationDTO(
+    id = id!!,
+    firstPrisonerNumber = firstPrisonerNumber,
+    firstPrisonerReason = firstPrisonerReason,
+    secondPrisonerNumber = secondPrisonerNumber,
+    secondPrisonerReason = secondPrisonerReason,
+    restrictionType = restrictionType,
+    comment = comment,
+    // TODO: Do we need to do anything special with this?
+    //       This field being optional in NOMIS/Prison API
+    //       It may be one of the things we make mandatory after migration?
+    authorisedBy = authorisedBy ?: "",
+  )
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/service/NonAssociationsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/service/NonAssociationsService.kt
@@ -34,32 +34,3 @@ class NonAssociationsService(
     return nonAssociationsRepository.save(nonAssociation)
   }
 }
-
-private fun CreateNonAssociationRequest.toNewEntity(authorisedBy: String): NonAssociationJPA {
-  return NonAssociationJPA(
-    id = null,
-    firstPrisonerNumber = firstPrisonerNumber,
-    firstPrisonerReason = firstPrisonerReason,
-    secondPrisonerNumber = secondPrisonerNumber,
-    secondPrisonerReason = secondPrisonerReason,
-    restrictionType = restrictionType,
-    comment = comment,
-    authorisedBy = authorisedBy,
-  )
-}
-
-private fun NonAssociationJPA.toDto(): NonAssociationDTO {
-  return NonAssociationDTO(
-    id = id!!,
-    firstPrisonerNumber = firstPrisonerNumber,
-    firstPrisonerReason = firstPrisonerReason,
-    secondPrisonerNumber = secondPrisonerNumber,
-    secondPrisonerReason = secondPrisonerReason,
-    restrictionType = restrictionType,
-    comment = comment,
-    // TODO: Do we need to do anything special with this?
-    //       This field being optional in NOMIS/Prison API
-    //       It may be one of the things we make mandatory after migration?
-    authorisedBy = authorisedBy ?: "",
-  )
-}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/jpa/repository/NonAssociationsRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/jpa/repository/NonAssociationsRepositoryTest.kt
@@ -27,7 +27,7 @@ import java.time.LocalDateTime
 class NonAssociationRepositoryTest : TestBase() {
 
   @Autowired
-  lateinit var repository: NonAssociationRepository
+  lateinit var repository: NonAssociationsRepository
 
   @Test
   fun createNonAssociation() {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/jpa/repository/NonAssociationsRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/jpa/repository/NonAssociationsRepositoryTest.kt
@@ -24,7 +24,7 @@ import java.time.LocalDateTime
 @Import(AuthenticationFacade::class, AuditorAwareImpl::class)
 @WithMockUser
 @Transactional
-class NonAssociationRepositoryTest : TestBase() {
+class NonAssociationsRepositoryTest : TestBase() {
 
   @Autowired
   lateinit var repository: NonAssociationsRepository

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/resource/NonAssociationsResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/resource/NonAssociationsResourceTest.kt
@@ -3,7 +3,6 @@ package uk.gov.justice.digital.hmpps.hmppsnonassociationsapi.resource
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import uk.gov.justice.digital.hmpps.hmppsnonassociationsapi.dto.CreateNonAssociationRequest
-import uk.gov.justice.digital.hmpps.hmppsnonassociationsapi.dto.NonAssociation
 import uk.gov.justice.digital.hmpps.hmppsnonassociationsapi.dto.NonAssociationReason
 import uk.gov.justice.digital.hmpps.hmppsnonassociationsapi.dto.NonAssociationRestrictionType
 import uk.gov.justice.digital.hmpps.hmppsnonassociationsapi.integration.IntegrationTestBase
@@ -123,20 +122,23 @@ class NonAssociationsResourceTest : IntegrationTestBase() {
       )
 
       val expectedUsername = "A_TEST_USER"
-      val expectedResponse = NonAssociation(
-        id = 1,
-        firstPrisonerNumber = request.firstPrisonerNumber,
-        firstPrisonerReason = request.firstPrisonerReason,
-        secondPrisonerNumber = request.secondPrisonerNumber,
-        secondPrisonerReason = request.secondPrisonerReason,
-        restrictionType = request.restrictionType,
-        comment = request.comment,
-        authorisedBy = expectedUsername,
-        isClosed = false,
-        closedReason = null,
-        closedBy = null,
-        closedAt = null,
-      )
+      val expectedResponse =
+        // language=json
+        """
+        {
+          "firstPrisonerNumber": "${request.firstPrisonerNumber}",
+          "firstPrisonerReason": "${request.firstPrisonerReason}",
+          "secondPrisonerNumber": "${request.secondPrisonerNumber}",
+          "secondPrisonerReason" = "${request.secondPrisonerReason}",
+          "restrictionType": "${request.restrictionType}",
+          "comment": "${request.comment}",
+          "authorisedBy": "$expectedUsername",
+          "isClosed": false,
+          "closedReason": null,
+          "closedBy": null,
+          "closedAt": null
+        }
+        """
 
       webTestClient.post()
         .uri(url)
@@ -151,10 +153,7 @@ class NonAssociationsResourceTest : IntegrationTestBase() {
         .bodyValue(jsonString(request))
         .exchange()
         .expectStatus().isCreated
-        .expectBody().json(
-          jsonString(expectedResponse),
-          true,
-        )
+        .expectBody().json(expectedResponse, false)
 
       // TODO: Make request to `GET /non-associations/{id}` once it exists
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/resource/NonAssociationsResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/resource/NonAssociationsResourceTest.kt
@@ -7,6 +7,7 @@ import uk.gov.justice.digital.hmpps.hmppsnonassociationsapi.dto.NonAssociation
 import uk.gov.justice.digital.hmpps.hmppsnonassociationsapi.dto.NonAssociationReason
 import uk.gov.justice.digital.hmpps.hmppsnonassociationsapi.dto.NonAssociationRestrictionType
 import uk.gov.justice.digital.hmpps.hmppsnonassociationsapi.integration.IntegrationTestBase
+import uk.gov.justice.digital.hmpps.hmppsnonassociationsapi.util.createNonAssociationRequest
 
 class NonAssociationsResourceTest : IntegrationTestBase() {
 
@@ -28,7 +29,7 @@ class NonAssociationsResourceTest : IntegrationTestBase() {
 
     @Test
     fun `without the correct role and scope responds 403 Forbidden`() {
-      val request = CreateNonAssociationRequest(
+      val request = createNonAssociationRequest(
         firstPrisonerNumber = "A1234BC",
         firstPrisonerReason = NonAssociationReason.VICTIM,
         secondPrisonerNumber = "D5678EF",
@@ -112,9 +113,30 @@ class NonAssociationsResourceTest : IntegrationTestBase() {
 
     @Test
     fun `for a valid request creates the non-association`() {
-      throw Exception("TODO: Make valid request")
+      val request = createNonAssociationRequest(
+        firstPrisonerNumber = "A1234BC",
+        firstPrisonerReason = NonAssociationReason.VICTIM,
+        secondPrisonerNumber = "D5678EF",
+        secondPrisonerReason = NonAssociationReason.PERPETRATOR,
+        restrictionType = NonAssociationRestrictionType.CELL,
+        comment = "They keep fighting",
+      )
 
-      val expectedResponse = jsonString(mapOf("prisonerNumber" to prisonerNumber))
+      val expectedResponse = NonAssociation(
+        id = 1,
+        firstPrisonerNumber = request.firstPrisonerNumber,
+        firstPrisonerReason = request.firstPrisonerReason,
+        secondPrisonerNumber = request.secondPrisonerNumber,
+        secondPrisonerReason = request.secondPrisonerReason,
+        restrictionType = request.restrictionType,
+        comment = request.comment,
+        authorisedBy = "TODO: userId of whoever made the request",
+        isClosed = false,
+        closedReason = null,
+        closedBy = null,
+        closedAt = null,
+      )
+
       webTestClient.post()
         .uri(url)
         .headers(
@@ -123,10 +145,12 @@ class NonAssociationsResourceTest : IntegrationTestBase() {
             scopes = listOf("write", "read"),
           ),
         )
+        .header("Content-Type", "application/json")
+        .bodyValue(jsonString(request))
         .exchange()
         .expectStatus().isCreated
         .expectBody().json(
-          expectedResponse,
+          jsonString(expectedResponse),
           true,
         )
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/resource/NonAssociationsResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/resource/NonAssociationsResourceTest.kt
@@ -113,7 +113,7 @@ class NonAssociationsResourceTest : IntegrationTestBase() {
 
     @Test
     fun `for a valid request creates the non-association`() {
-      val request = createNonAssociationRequest(
+      val request: CreateNonAssociationRequest = createNonAssociationRequest(
         firstPrisonerNumber = "A1234BC",
         firstPrisonerReason = NonAssociationReason.VICTIM,
         secondPrisonerNumber = "D5678EF",
@@ -122,6 +122,7 @@ class NonAssociationsResourceTest : IntegrationTestBase() {
         comment = "They keep fighting",
       )
 
+      val expectedUsername = "A_TEST_USER"
       val expectedResponse = NonAssociation(
         id = 1,
         firstPrisonerNumber = request.firstPrisonerNumber,
@@ -130,7 +131,7 @@ class NonAssociationsResourceTest : IntegrationTestBase() {
         secondPrisonerReason = request.secondPrisonerReason,
         restrictionType = request.restrictionType,
         comment = request.comment,
-        authorisedBy = "TODO: userId of whoever made the request",
+        authorisedBy = expectedUsername,
         isClosed = false,
         closedReason = null,
         closedBy = null,
@@ -141,6 +142,7 @@ class NonAssociationsResourceTest : IntegrationTestBase() {
         .uri(url)
         .headers(
           setAuthorisation(
+            user = expectedUsername,
             roles = listOf("ROLE_NON_ASSOCIATIONS"),
             scopes = listOf("write", "read"),
           ),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/resource/NonAssociationsResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/resource/NonAssociationsResourceTest.kt
@@ -9,6 +9,110 @@ class NonAssociationsResourceTest : IntegrationTestBase() {
   final val prisonerNumber = "A1234BC"
 
   @Nested
+  inner class `Create a non-association` {
+
+    private val url = "/non-associations"
+
+    @Test
+    fun `without a valid token responds 401 Unauthorized`() {
+      webTestClient.post()
+        .uri(url)
+        .exchange()
+        .expectStatus()
+        .isUnauthorized
+    }
+
+    @Test
+    fun `without the correct role and scope responds 403 Forbidden`() {
+      // correct role, missing write scope
+      webTestClient.post()
+        .uri(url)
+        .headers(setAuthorisation(roles = listOf("ROLE_NON_ASSOCIATIONS")))
+        .header("Content-Type", "application/json")
+        .bodyValue(
+          // language=json
+          "{}",
+        )
+        .exchange()
+        .expectStatus()
+        .isForbidden
+
+      // correct role, missing write scope
+      webTestClient.post()
+        .uri(url)
+        .headers(
+          setAuthorisation(
+            roles = listOf("ROLE_NON_ASSOCIATIONS"),
+            scopes = listOf("read"),
+          ),
+        )
+        .header("Content-Type", "application/json")
+        .bodyValue(
+          // language=json
+          "{}",
+        )
+        .exchange()
+        .expectStatus()
+        .isForbidden
+    }
+
+    @Test
+    fun `without a valid request body responds 400 Bad Request`() {
+      // no request body
+      webTestClient.post()
+        .uri(url)
+        .headers(
+          setAuthorisation(
+            roles = listOf("ROLE_NON_ASSOCIATIONS"),
+            scopes = listOf("write"),
+          ),
+        )
+        .header("Content-Type", "application/json")
+        .exchange()
+        .expectStatus()
+        .isBadRequest
+
+      // unsupported Content-Type
+      webTestClient.post()
+        .uri(url)
+        .headers(
+          setAuthorisation(
+            roles = listOf("ROLE_NON_ASSOCIATIONS"),
+            scopes = listOf("write"),
+          ),
+        )
+        .header("Content-Type", "text/plain")
+        .bodyValue("{}")
+        .exchange()
+        .expectStatus()
+        .isBadRequest
+    }
+
+    @Test
+    fun `for a valid request creates the non-association`() {
+      throw Exception("TODO: Make valid request")
+
+      val expectedResponse = jsonString(mapOf("prisonerNumber" to prisonerNumber))
+      webTestClient.post()
+        .uri(url)
+        .headers(
+          setAuthorisation(
+            roles = listOf("ROLE_NON_ASSOCIATIONS"),
+            scopes = listOf("write", "read"),
+          ),
+        )
+        .exchange()
+        .expectStatus().isCreated
+        .expectBody().json(
+          expectedResponse,
+          true,
+        )
+
+      // TODO: Make request to `GET /non-associations/{id}` once it exists
+    }
+  }
+
+  @Nested
   inner class `GET non associations for a prisoner` {
 
     private val url = "/prisoner/$prisonerNumber/non-associations"

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/service/NonAssociationsServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/service/NonAssociationsServiceTest.kt
@@ -1,0 +1,57 @@
+package uk.gov.justice.digital.hmpps.hmppsnonassociationsapi.service
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import uk.gov.justice.digital.hmpps.hmppsnonassociationsapi.config.AuthenticationFacade
+import uk.gov.justice.digital.hmpps.hmppsnonassociationsapi.dto.CreateNonAssociationRequest
+import uk.gov.justice.digital.hmpps.hmppsnonassociationsapi.jpa.repository.NonAssociationsRepository
+import uk.gov.justice.digital.hmpps.hmppsnonassociationsapi.util.createNonAssociationRequest
+import uk.gov.justice.digital.hmpps.hmppsnonassociationsapi.dto.NonAssociation as NonAssociationDTO
+import uk.gov.justice.digital.hmpps.hmppsnonassociationsapi.jpa.NonAssociation as NonAssociationJPA
+
+class NonAssociationsServiceTest {
+
+  private val nonAssociationsRepository: NonAssociationsRepository = mock()
+  private val prisonApiService: PrisonApiService = mock()
+  private val authenticationFacade: AuthenticationFacade = mock()
+  private val service = NonAssociationsService(
+    nonAssociationsRepository,
+    authenticationFacade,
+    prisonApiService,
+  )
+
+  @Test
+  fun createNonAssociation() {
+    val createNonAssociationRequest: CreateNonAssociationRequest = createNonAssociationRequest()
+
+    val authorisedBy = "TEST_USER_GEN"
+    whenever(authenticationFacade.currentUsername).thenReturn(authorisedBy)
+
+    val expectedId = 42L
+    val createdNonAssociationJPA = NonAssociationJPA(
+      id = expectedId,
+      firstPrisonerNumber = createNonAssociationRequest.firstPrisonerNumber,
+      firstPrisonerReason = createNonAssociationRequest.firstPrisonerReason,
+      secondPrisonerNumber = createNonAssociationRequest.secondPrisonerNumber,
+      secondPrisonerReason = createNonAssociationRequest.secondPrisonerReason,
+      comment = createNonAssociationRequest.comment,
+      restrictionType = createNonAssociationRequest.restrictionType,
+      authorisedBy = authorisedBy,
+      isClosed = false,
+      closedBy = null,
+      closedReason = null,
+      closedAt = null,
+    )
+
+    whenever(nonAssociationsRepository.save(any()))
+      .thenReturn(createdNonAssociationJPA)
+
+    val createdNonAssociationDTO: NonAssociationDTO = service.createNonAssociation(createNonAssociationRequest)
+
+    val expectedCreatedNonAssociationDTO = createdNonAssociationJPA.toDto()
+    assertThat(createdNonAssociationDTO).isEqualTo(expectedCreatedNonAssociationDTO)
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/util/TestData.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/util/TestData.kt
@@ -1,0 +1,29 @@
+package uk.gov.justice.digital.hmpps.hmppsnonassociationsapi.util
+
+import uk.gov.justice.digital.hmpps.hmppsnonassociationsapi.dto.CreateNonAssociationRequest
+import uk.gov.justice.digital.hmpps.hmppsnonassociationsapi.dto.NonAssociationReason
+import uk.gov.justice.digital.hmpps.hmppsnonassociationsapi.dto.NonAssociationRestrictionType
+
+/**
+ * Returns a test CreateNonAssociationRequest
+ *
+ * Arguments are all optional with good (test) defaults so that you don't have to
+ * pass all non-association fields when you just need a valid value.
+ */
+fun createNonAssociationRequest(
+  firstPrisonerNumber: String = "A1234BC",
+  firstPrisonerReason: NonAssociationReason = NonAssociationReason.VICTIM,
+  secondPrisonerNumber: String = "D5678EF",
+  secondPrisonerReason: NonAssociationReason = NonAssociationReason.PERPETRATOR,
+  comment: String = "test comment",
+  restrictionType: NonAssociationRestrictionType = NonAssociationRestrictionType.CELL,
+): CreateNonAssociationRequest {
+  return CreateNonAssociationRequest(
+    firstPrisonerNumber = firstPrisonerNumber,
+    firstPrisonerReason = firstPrisonerReason,
+    secondPrisonerNumber = secondPrisonerNumber,
+    secondPrisonerReason = secondPrisonerReason,
+    comment = comment,
+    restrictionType = restrictionType,
+  )
+}


### PR DESCRIPTION
- ability to create a non-association (open). required `ROLE_NON_ASSOCIATIONS` role with `write` scope
- better handling of some validation exceptions
- non-association `comment` is mandatory in JPA entity (was already non-nullable in DB)