### PR TITLE
NON-87: Get single non association by ID

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/config/HmppsNonAssociationsApiExceptionHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/config/HmppsNonAssociationsApiExceptionHandler.kt
@@ -71,8 +71,22 @@ class HmppsNonAssociationsApiExceptionHandler {
       )
   }
 
+  @ExceptionHandler(NonAssociationNotFoundException::class)
+  fun handleNotFound(e: NonAssociationNotFoundException): ResponseEntity<ErrorResponse?>? {
+    log.debug("Not found exception caught: {}", e.message)
+    return ResponseEntity
+      .status(HttpStatus.NOT_FOUND)
+      .body(
+        ErrorResponse(
+          status = HttpStatus.NOT_FOUND,
+          userMessage = "Not Found: ${e.message}",
+          developerMessage = e.message,
+        ),
+      )
+  }
+
   @ExceptionHandler(NotFound::class)
-  fun handleNotFound(e: NotFound): ResponseEntity<ErrorResponse?>? {
+  fun handleSpringNotFound(e: NotFound): ResponseEntity<ErrorResponse?>? {
     log.debug("Not found exception caught: {}", e.message)
     return ResponseEntity
       .status(HttpStatus.NOT_FOUND)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/config/HmppsNonAssociationsApiExceptionHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/config/HmppsNonAssociationsApiExceptionHandler.kt
@@ -104,6 +104,9 @@ class HmppsNonAssociationsApiExceptionHandler {
   }
 }
 
+class NonAssociationNotFoundException(id: Long) :
+  Exception("Non-association with ID $id not found")
+
 data class ErrorResponse(
   val status: Int,
   val errorCode: Int? = null,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/resource/NonAssociationsResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/resource/NonAssociationsResource.kt
@@ -27,7 +27,7 @@ import uk.gov.justice.digital.hmpps.hmppsnonassociationsapi.services.NonAssociat
 @RestController
 @Validated
 @RequestMapping("/", produces = [MediaType.APPLICATION_JSON_VALUE])
-@Tag(name = "Non-Associations", description = "Retrieve non-associations")
+@Tag(name = "Non-Associations", description = "**IMPORTANT**: This is a work in progress API and it's subject to change, DO NOT USE.")
 class NonAssociationsResource(
   private val nonAssociationsService: NonAssociationsService,
 ) : NonAssociationsBaseResource() {
@@ -35,7 +35,7 @@ class NonAssociationsResource(
   @PreAuthorize("hasRole('ROLE_NON_ASSOCIATIONS')")
   @ResponseStatus(HttpStatus.OK)
   @Operation(
-    summary = "**IMPORTANT**: This is a work in progress API and it's subject to change, DO NOT USE. Get non-associations by prisoner number. Requires ROLE_NON_ASSOCIATIONS role.",
+    summary = "Get non-associations by prisoner number. Requires ROLE_NON_ASSOCIATIONS role.",
     description = "The offender prisoner number",
     responses = [
       ApiResponse(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/resource/NonAssociationsResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/resource/NonAssociationsResource.kt
@@ -96,6 +96,7 @@ class NonAssociationsResource(
   )
   fun createNonAssociation(
     @RequestBody
+    @Validated
     createNonAssociation: CreateNonAssociationRequest,
   ): NonAssociation =
     eventPublishWrapper(NonAssociationDomainEventType.NON_ASSOCIATION_CREATED) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/resource/NonAssociationsResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/resource/NonAssociationsResource.kt
@@ -16,8 +16,8 @@ import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.server.ResponseStatusException
 import uk.gov.justice.digital.hmpps.hmppsnonassociationsapi.config.ErrorResponse
-import uk.gov.justice.digital.hmpps.hmppsnonassociationsapi.config.NonAssociationNotFoundException
 import uk.gov.justice.digital.hmpps.hmppsnonassociationsapi.dto.CreateNonAssociationRequest
 import uk.gov.justice.digital.hmpps.hmppsnonassociationsapi.dto.NonAssociation
 import uk.gov.justice.digital.hmpps.hmppsnonassociationsapi.dto.NonAssociationDetails
@@ -137,6 +137,9 @@ class NonAssociationsResource(
     @PathVariable
     id: Long,
   ): NonAssociation {
-    return nonAssociationsService.getById(id) ?: throw NonAssociationNotFoundException(id)
+    return nonAssociationsService.getById(id) ?: throw ResponseStatusException(
+      HttpStatus.NOT_FOUND,
+      "Non-association with ID $id not found",
+    )
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/service/NonAssociationsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/service/NonAssociationsService.kt
@@ -6,6 +6,7 @@ import uk.gov.justice.digital.hmpps.hmppsnonassociationsapi.config.Authenticatio
 import uk.gov.justice.digital.hmpps.hmppsnonassociationsapi.dto.CreateNonAssociationRequest
 import uk.gov.justice.digital.hmpps.hmppsnonassociationsapi.dto.prisonapi.LegacyNonAssociationDetails
 import uk.gov.justice.digital.hmpps.hmppsnonassociationsapi.jpa.repository.NonAssociationsRepository
+import kotlin.jvm.optionals.getOrNull
 import uk.gov.justice.digital.hmpps.hmppsnonassociationsapi.dto.NonAssociation as NonAssociationDTO
 import uk.gov.justice.digital.hmpps.hmppsnonassociationsapi.jpa.NonAssociation as NonAssociationJPA
 
@@ -22,6 +23,10 @@ class NonAssociationsService(
       authorisedBy = authenticationFacade.currentUsername ?: throw Exception("Could not determine current user's username'"),
     )
     return persistNonAssociation(nonAssociationJpa).toDto()
+  }
+
+  fun getById(id: Long): NonAssociationDTO? {
+    return nonAssociationsRepository.findById(id).getOrNull()?.toDto()
   }
 
   fun getDetails(prisonerNumber: String): LegacyNonAssociationDetails {

--- a/src/main/resources/db/migration/V1_8__non_association__increase_authorised_by_length.sql
+++ b/src/main/resources/db/migration/V1_8__non_association__increase_authorised_by_length.sql
@@ -1,0 +1,3 @@
+-- Increase length of `authorised_by` column to 60 chars as in NOMIS
+ALTER TABLE non_association
+ALTER COLUMN authorised_by TYPE VARCHAR(60);

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/resource/NonAssociationsResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/resource/NonAssociationsResourceTest.kt
@@ -2,7 +2,10 @@ package uk.gov.justice.digital.hmpps.hmppsnonassociationsapi.resource
 
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import org.springframework.test.web.reactive.server.expectBody
+import org.springframework.test.web.reactive.server.returnResult
 import uk.gov.justice.digital.hmpps.hmppsnonassociationsapi.dto.CreateNonAssociationRequest
+import uk.gov.justice.digital.hmpps.hmppsnonassociationsapi.dto.NonAssociation
 import uk.gov.justice.digital.hmpps.hmppsnonassociationsapi.dto.NonAssociationReason
 import uk.gov.justice.digital.hmpps.hmppsnonassociationsapi.dto.NonAssociationRestrictionType
 import uk.gov.justice.digital.hmpps.hmppsnonassociationsapi.integration.SqsIntegrationTestBase
@@ -156,6 +159,98 @@ class NonAssociationsResourceTest : SqsIntegrationTestBase() {
         .expectBody().json(expectedResponse, false)
 
       // TODO: Make request to `GET /non-associations/{id}` once it exists
+    }
+  }
+
+  @Nested
+  inner class `Get a non-association` {
+
+    private val url = "/non-associations"
+
+    @Test
+    fun `without a valid token responds 401 Unauthorized`() {
+      webTestClient.get()
+        .uri("/non-associations/42")
+        .exchange()
+        .expectStatus()
+        .isUnauthorized
+    }
+
+    @Test
+    fun `without the correct role responds 403 Forbidden`() {
+      val existingNonAssociation = createNonAssociation()
+
+      // wrong role
+      webTestClient.get()
+        .uri("/non-associations/${existingNonAssociation.id}")
+        .headers(setAuthorisation(roles = listOf("ROLE_SOMETHING_ELSE")))
+        .header("Content-Type", "application/json")
+        .exchange()
+        .expectStatus()
+        .isForbidden
+    }
+
+    @Test
+    fun `when the non-association doesn't exist responds 404 Not Found`() {
+      webTestClient.get()
+        .uri("/non-associations/42")
+        .headers(setAuthorisation(roles = listOf("ROLE_NON_ASSOCIATIONS")))
+        .header("Content-Type", "application/json")
+        .exchange()
+        .expectStatus()
+        .isNotFound
+    }
+
+    @Test
+    fun `when the non-association exists returns it`() {
+      val existingNonAssociation = createNonAssociation()
+
+      webTestClient.get()
+        .uri("/non-associations/${existingNonAssociation.id}")
+        .headers(
+          setAuthorisation(
+            roles = listOf("ROLE_NON_ASSOCIATIONS"),
+          ),
+        )
+        .header("Content-Type", "application/json")
+        .exchange()
+        .expectStatus()
+        .isOk
+        .expectBody()
+        .jsonPath("id").isEqualTo(existingNonAssociation.id)
+        .jsonPath("firstPrisonerNumber").isEqualTo(existingNonAssociation.firstPrisonerNumber)
+        .jsonPath("firstPrisonerReason").isEqualTo(existingNonAssociation.firstPrisonerReason.toString())
+        .jsonPath("secondPrisonerNumber").isEqualTo(existingNonAssociation.secondPrisonerNumber)
+        .jsonPath("secondPrisonerReason").isEqualTo(existingNonAssociation.secondPrisonerReason.toString())
+        .jsonPath("restrictionType").isEqualTo(existingNonAssociation.restrictionType.toString())
+        .jsonPath("comment").isEqualTo(existingNonAssociation.comment)
+    }
+
+    private fun createNonAssociation(): NonAssociation {
+      val createRequest: CreateNonAssociationRequest = createNonAssociationRequest(
+        firstPrisonerNumber = "A1234BC",
+        firstPrisonerReason = NonAssociationReason.VICTIM,
+        secondPrisonerNumber = "D5678EF",
+        secondPrisonerReason = NonAssociationReason.PERPETRATOR,
+        restrictionType = NonAssociationRestrictionType.CELL,
+        comment = "They keep fighting",
+      )
+
+      return webTestClient.post()
+        .uri(url)
+        .headers(
+          setAuthorisation(
+            roles = listOf("ROLE_NON_ASSOCIATIONS"),
+            scopes = listOf("write", "read"),
+          ),
+        )
+        .header("Content-Type", "application/json")
+        .bodyValue(jsonString(createRequest))
+        .exchange()
+        .expectStatus().isCreated
+        .returnResult<NonAssociation>()
+        .responseBody
+        .blockFirst()
     }
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/resource/NonAssociationsResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/resource/NonAssociationsResourceTest.kt
@@ -2,7 +2,6 @@ package uk.gov.justice.digital.hmpps.hmppsnonassociationsapi.resource
 
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
-import org.springframework.test.web.reactive.server.expectBody
 import org.springframework.test.web.reactive.server.returnResult
 import uk.gov.justice.digital.hmpps.hmppsnonassociationsapi.dto.CreateNonAssociationRequest
 import uk.gov.justice.digital.hmpps.hmppsnonassociationsapi.dto.NonAssociation


### PR DESCRIPTION
Added `GET /non-associations/{id}` endpoint to retrieve a single non-association