### PR TITLE
NON-88: Filtering for endpoint to get a prisoner non-associations

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/dto/NonAssociation.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/dto/NonAssociation.kt
@@ -8,7 +8,7 @@ import uk.gov.justice.digital.hmpps.hmppsnonassociationsapi.jpa.NonAssociation a
  * Non-association between two prisoners
  */
 data class NonAssociation(
-  @Schema(description = "ID of the non-association", required = false, example = "42")
+  @Schema(description = "ID of the non-association", required = true, example = "42")
   val id: Long,
 
   @Schema(description = "Prisoner number to not associate", required = true, example = "A1234BC")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/dto/PrisonerNonAssociations.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/dto/PrisonerNonAssociations.kt
@@ -56,7 +56,7 @@ data class NonAssociationDetails(
   @Schema(description = "Reason why the non-association was closed. Only present when the non-association is closed, null for open non-associations", required = false, example = "null")
   val closedReason: String? = null,
   @Schema(description = "Date and time of when the non-association was closed. Only present when the non-association is closed, null for open non-associations", required = false, example = "null")
-  val closedAt: String? = null,
+  val closedAt: LocalDateTime? = null,
 
   @Schema(description = "Details about the other person in the non-association.", required = true)
   val otherPrisonerDetails: OtherPrisonerDetails,
@@ -147,6 +147,12 @@ private fun List<NonAssociationJPA>.toNonAssociationsDetails(
       comment = nonna.comment,
       authorisedBy = nonna.authorisedBy ?: "",
       whenCreated = nonna.whenCreated,
+
+      isClosed = nonna.isClosed,
+      closedBy = nonna.closedBy,
+      closedReason = nonna.closedReason,
+      closedAt = nonna.closedAt,
+
       otherPrisonerDetails = OtherPrisonerDetails(
         prisonerNumber = otherPrisoner.prisonerNumber,
         reasonCode = otherReason,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/dto/PrisonerNonAssociations.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/dto/PrisonerNonAssociations.kt
@@ -33,6 +33,9 @@ data class PrisonerNonAssociations(
  * Details about a single non-association and link to the other prisoner involved
  */
 data class NonAssociationDetails(
+  @Schema(description = "ID of the non-association", required = true, example = "42")
+  val id: Long,
+
   @Schema(description = "Reason code for the non-association", required = true, example = "VICTIM")
   val reasonCode: NonAssociationReason,
   @Schema(description = "Reason description for the non-association", required = true, example = "Victim")
@@ -140,6 +143,7 @@ private fun List<NonAssociationJPA>.toNonAssociationsDetails(
     val (_, otherPrisoner, reason, otherReason) = prisonersInfo
 
     NonAssociationDetails(
+      id = nonna.id ?: throw Exception("Only persisted non-associations can used to build a PrisonerNonAssociations instance"),
       reasonCode = reason,
       reasonDescription = reason.description,
       restrictionTypeCode = nonna.restrictionType,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/resource/NonAssociationsResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/resource/NonAssociationsResource.kt
@@ -68,8 +68,8 @@ class NonAssociationsResource(
     return nonAssociationsService.getPrisonerNonAssociations(
       prisonerNumber,
       NonAssociationListOptions(
-        onlySamePrison = true,
         includeClosed = false,
+        includeOtherPrisons = false,
       ),
     )
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/resource/NonAssociationsResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/resource/NonAssociationsResource.kt
@@ -74,12 +74,21 @@ class NonAssociationsResource(
     )
     @RequestParam(required = false)
     includeClosed: Boolean,
+
+    @Schema(
+      description = "Whether to include non-associations with prisoners in other prisons",
+      required = false,
+      defaultValue = "false",
+      example = "true",
+    )
+    @RequestParam(required = false)
+    includeOtherPrisons: Boolean,
   ): PrisonerNonAssociations {
     return nonAssociationsService.getPrisonerNonAssociations(
       prisonerNumber,
       NonAssociationListOptions(
         includeClosed = includeClosed,
-        includeOtherPrisons = false,
+        includeOtherPrisons = includeOtherPrisons,
       ),
     )
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/resource/NonAssociationsResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/resource/NonAssociationsResource.kt
@@ -14,6 +14,7 @@ import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
 import org.springframework.web.server.ResponseStatusException
@@ -64,11 +65,20 @@ class NonAssociationsResource(
     @Schema(description = "The offender prisoner number", example = "A1234BC", required = true)
     @PathVariable
     prisonerNumber: String,
+
+    @Schema(
+      description = "Whether to include closed non-associations or not",
+      required = false,
+      defaultValue = "false",
+      example = "true",
+    )
+    @RequestParam(required = false)
+    includeClosed: Boolean,
   ): PrisonerNonAssociations {
     return nonAssociationsService.getPrisonerNonAssociations(
       prisonerNumber,
       NonAssociationListOptions(
-        includeClosed = false,
+        includeClosed = includeClosed,
         includeOtherPrisons = false,
       ),
     )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/service/NonAssociationsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/service/NonAssociationsService.kt
@@ -59,7 +59,7 @@ class NonAssociationsService(
 
     var nonAssociationsFiltered = nonAssociations
     // filter out non-associations in other prisons
-    if (options.onlySamePrison) {
+    if (!options.includeOtherPrisons) {
       val prisonId = prisoners[prisonerNumber]!!.prisonId
       nonAssociationsFiltered = nonAssociationsFiltered.filter { nonna ->
         prisoners[nonna.firstPrisonerNumber]!!.prisonId == prisonId &&
@@ -86,6 +86,6 @@ class NonAssociationsService(
 }
 
 data class NonAssociationListOptions(
-  val onlySamePrison: Boolean = true,
+  val includeOtherPrisons: Boolean = false,
   val includeClosed: Boolean = false,
 )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/resource/NonAssociationsResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/resource/NonAssociationsResourceTest.kt
@@ -353,40 +353,40 @@ class NonAssociationsResourceTest : SqsIntegrationTestBase() {
     @Test
     fun `by default returns only open non-associations in same prison the given prisoner is in`() {
       // prisoners in MDI
-      val firstPrisoner = offenderSearchPrisoners["A1234BC"]!!
-      val secondPrisoner = offenderSearchPrisoners["D5678EF"]!!
-      val thirdPrisoner = offenderSearchPrisoners["G9012HI"]!!
+      val prisonerJohn = offenderSearchPrisoners["A1234BC"]!!
+      val prisonerMerlin = offenderSearchPrisoners["D5678EF"]!!
+      val prisonerJosh = offenderSearchPrisoners["G9012HI"]!!
       // prisoner in another prison
-      val fourthPrisoner = offenderSearchPrisoners["L3456MN"]!!
+      val prisonerEdward = offenderSearchPrisoners["L3456MN"]!!
 
       // open non-association, same prison
       val openNonAssociation = createNonAssociation(
-        firstPrisoner.prisonerNumber,
-        secondPrisoner.prisonerNumber,
+        prisonerJohn.prisonerNumber,
+        prisonerMerlin.prisonerNumber,
         isClosed = false,
       )
 
       // closed non-association, same prison, not returned
       val closedNonAssociation = createNonAssociation(
-        firstPrisonerNumber = secondPrisoner.prisonerNumber,
-        secondPrisonerNumber = thirdPrisoner.prisonerNumber,
+        firstPrisonerNumber = prisonerMerlin.prisonerNumber,
+        secondPrisonerNumber = prisonerJosh.prisonerNumber,
         isClosed = true,
       )
 
       // non-association with someone in a different prison, not returned
       val otherPrisonNonAssociation = createNonAssociation(
-        firstPrisonerNumber = fourthPrisoner.prisonerNumber,
-        secondPrisonerNumber = secondPrisoner.prisonerNumber,
+        firstPrisonerNumber = prisonerEdward.prisonerNumber,
+        secondPrisonerNumber = prisonerMerlin.prisonerNumber,
       )
 
-      val prisoners = listOf(firstPrisoner, secondPrisoner, thirdPrisoner, fourthPrisoner)
+      val prisoners = listOf(prisonerJohn, prisonerMerlin, prisonerJosh, prisonerEdward)
       offenderSearchMockServer.stubSearchByPrisonerNumbers(
         prisonerNumbers = prisoners.map(OffenderSearchPrisoner::prisonerNumber),
         prisoners,
       )
 
-      // NOTE: Non-associations for the 2nd prisoner
-      val url = "/prisoner/${secondPrisoner.prisonerNumber}/non-associations"
+      // NOTE: Non-associations for Merlin
+      val url = "/prisoner/${prisonerMerlin.prisonerNumber}/non-associations"
       webTestClient.get()
         .uri(url)
         .headers(setAuthorisation(roles = listOf("ROLE_NON_ASSOCIATIONS")))
@@ -396,12 +396,12 @@ class NonAssociationsResourceTest : SqsIntegrationTestBase() {
           // language=json
           """
             {
-              "prisonerNumber": "${secondPrisoner.prisonerNumber}",
-              "firstName": "${secondPrisoner.firstName}",
-              "lastName": "${secondPrisoner.lastName}",
-              "prisonId": "${secondPrisoner.prisonId}",
-              "prisonName": "${secondPrisoner.prisonName}",
-              "cellLocation": "${secondPrisoner.cellLocation}",
+              "prisonerNumber": "${prisonerMerlin.prisonerNumber}",
+              "firstName": "${prisonerMerlin.firstName}",
+              "lastName": "${prisonerMerlin.lastName}",
+              "prisonId": "${prisonerMerlin.prisonId}",
+              "prisonName": "${prisonerMerlin.prisonName}",
+              "cellLocation": "${prisonerMerlin.cellLocation}",
               "nonAssociations": [
                 {
                   "reasonCode": "${openNonAssociation.secondPrisonerReason}",
@@ -415,14 +415,14 @@ class NonAssociationsResourceTest : SqsIntegrationTestBase() {
                   "closedBy": null,
                   "closedAt": null,
                   "otherPrisonerDetails": {
-                    "prisonerNumber": "${firstPrisoner.prisonerNumber}",
+                    "prisonerNumber": "${prisonerJohn.prisonerNumber}",
                     "reasonCode": "${openNonAssociation.firstPrisonerReason}",
                     "reasonDescription": "${openNonAssociation.firstPrisonerReason.description}",
-                    "firstName": "${firstPrisoner.firstName}",
-                    "lastName": "${firstPrisoner.lastName}",
-                    "prisonId": "${firstPrisoner.prisonId}",
-                    "prisonName": "${firstPrisoner.prisonName}",
-                    "cellLocation": "${firstPrisoner.cellLocation}"
+                    "firstName": "${prisonerJohn.firstName}",
+                    "lastName": "${prisonerJohn.lastName}",
+                    "prisonId": "${prisonerJohn.prisonId}",
+                    "prisonName": "${prisonerJohn.prisonName}",
+                    "cellLocation": "${prisonerJohn.cellLocation}"
                   }
                 }
               ]
@@ -435,40 +435,40 @@ class NonAssociationsResourceTest : SqsIntegrationTestBase() {
     @Test
     fun `optionally returns closed non-associations`() {
       // prisoners in MDI
-      val firstPrisoner = offenderSearchPrisoners["A1234BC"]!!
-      val secondPrisoner = offenderSearchPrisoners["D5678EF"]!!
-      val thirdPrisoner = offenderSearchPrisoners["G9012HI"]!!
+      val prisonerJohn = offenderSearchPrisoners["A1234BC"]!!
+      val prisonerMerlin = offenderSearchPrisoners["D5678EF"]!!
+      val prisonerJosh = offenderSearchPrisoners["G9012HI"]!!
       // prisoner in another prison
-      val fourthPrisoner = offenderSearchPrisoners["L3456MN"]!!
+      val prisonerEdward = offenderSearchPrisoners["L3456MN"]!!
 
       // open non-association, same prison
       val openNonAssociation = createNonAssociation(
-        firstPrisoner.prisonerNumber,
-        secondPrisoner.prisonerNumber,
+        prisonerJohn.prisonerNumber,
+        prisonerMerlin.prisonerNumber,
         isClosed = false,
       )
 
       // closed non-association, same prison, not returned
       val closedNonAssociation = createNonAssociation(
-        firstPrisonerNumber = secondPrisoner.prisonerNumber,
-        secondPrisonerNumber = thirdPrisoner.prisonerNumber,
+        firstPrisonerNumber = prisonerMerlin.prisonerNumber,
+        secondPrisonerNumber = prisonerJosh.prisonerNumber,
         isClosed = true,
       )
 
       // non-association with someone in a different prison, not returned
       val otherPrisonNonAssociation = createNonAssociation(
-        firstPrisonerNumber = fourthPrisoner.prisonerNumber,
-        secondPrisonerNumber = secondPrisoner.prisonerNumber,
+        firstPrisonerNumber = prisonerEdward.prisonerNumber,
+        secondPrisonerNumber = prisonerMerlin.prisonerNumber,
       )
 
-      val prisoners = listOf(firstPrisoner, secondPrisoner, thirdPrisoner, fourthPrisoner)
+      val prisoners = listOf(prisonerJohn, prisonerMerlin, prisonerJosh, prisonerEdward)
       offenderSearchMockServer.stubSearchByPrisonerNumbers(
         prisonerNumbers = prisoners.map(OffenderSearchPrisoner::prisonerNumber),
         prisoners,
       )
 
-      // NOTE: Non-associations for the 2nd prisoner
-      val url = "/prisoner/${secondPrisoner.prisonerNumber}/non-associations?includeClosed=true"
+      // NOTE: Non-associations for Merlin
+      val url = "/prisoner/${prisonerMerlin.prisonerNumber}/non-associations?includeClosed=true"
       webTestClient.get()
         .uri(url)
         .headers(setAuthorisation(roles = listOf("ROLE_NON_ASSOCIATIONS")))
@@ -478,12 +478,12 @@ class NonAssociationsResourceTest : SqsIntegrationTestBase() {
           // language=json
           """
             {
-              "prisonerNumber": "${secondPrisoner.prisonerNumber}",
-              "firstName": "${secondPrisoner.firstName}",
-              "lastName": "${secondPrisoner.lastName}",
-              "prisonId": "${secondPrisoner.prisonId}",
-              "prisonName": "${secondPrisoner.prisonName}",
-              "cellLocation": "${secondPrisoner.cellLocation}",
+              "prisonerNumber": "${prisonerMerlin.prisonerNumber}",
+              "firstName": "${prisonerMerlin.firstName}",
+              "lastName": "${prisonerMerlin.lastName}",
+              "prisonId": "${prisonerMerlin.prisonId}",
+              "prisonName": "${prisonerMerlin.prisonName}",
+              "cellLocation": "${prisonerMerlin.cellLocation}",
               "nonAssociations": [
                 {
                   "reasonCode": "${openNonAssociation.secondPrisonerReason}",
@@ -497,14 +497,14 @@ class NonAssociationsResourceTest : SqsIntegrationTestBase() {
                   "closedBy": null,
                   "closedAt": null,
                   "otherPrisonerDetails": {
-                    "prisonerNumber": "${firstPrisoner.prisonerNumber}",
+                    "prisonerNumber": "${prisonerJohn.prisonerNumber}",
                     "reasonCode": "${openNonAssociation.firstPrisonerReason}",
                     "reasonDescription": "${openNonAssociation.firstPrisonerReason.description}",
-                    "firstName": "${firstPrisoner.firstName}",
-                    "lastName": "${firstPrisoner.lastName}",
-                    "prisonId": "${firstPrisoner.prisonId}",
-                    "prisonName": "${firstPrisoner.prisonName}",
-                    "cellLocation": "${firstPrisoner.cellLocation}"
+                    "firstName": "${prisonerJohn.firstName}",
+                    "lastName": "${prisonerJohn.lastName}",
+                    "prisonId": "${prisonerJohn.prisonId}",
+                    "prisonName": "${prisonerJohn.prisonName}",
+                    "cellLocation": "${prisonerJohn.cellLocation}"
                   }
                 },
                 {
@@ -518,14 +518,14 @@ class NonAssociationsResourceTest : SqsIntegrationTestBase() {
                   "closedReason": "They're friends now",
                   "closedBy": "CLOSE_USER",
                   "otherPrisonerDetails": {
-                    "prisonerNumber": "${thirdPrisoner.prisonerNumber}",
+                    "prisonerNumber": "${prisonerJosh.prisonerNumber}",
                     "reasonCode": "${closedNonAssociation.secondPrisonerReason}",
                     "reasonDescription": "${closedNonAssociation.secondPrisonerReason.description}",
-                    "firstName": "${thirdPrisoner.firstName}",
-                    "lastName": "${thirdPrisoner.lastName}",
-                    "prisonId": "${thirdPrisoner.prisonId}",
-                    "prisonName": "${thirdPrisoner.prisonName}",
-                    "cellLocation": "${thirdPrisoner.cellLocation}"
+                    "firstName": "${prisonerJosh.firstName}",
+                    "lastName": "${prisonerJosh.lastName}",
+                    "prisonId": "${prisonerJosh.prisonId}",
+                    "prisonName": "${prisonerJosh.prisonName}",
+                    "cellLocation": "${prisonerJosh.cellLocation}"
                   }
                 }
               ]

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/resource/NonAssociationsResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/resource/NonAssociationsResourceTest.kt
@@ -404,6 +404,7 @@ class NonAssociationsResourceTest : SqsIntegrationTestBase() {
               "cellLocation": "${prisonerMerlin.cellLocation}",
               "nonAssociations": [
                 {
+                  "id": ${openNonAssociation.id},
                   "reasonCode": "${openNonAssociation.secondPrisonerReason}",
                   "reasonDescription": "${openNonAssociation.secondPrisonerReason.description}",
                   "restrictionTypeCode": "${openNonAssociation.restrictionType}",
@@ -486,6 +487,7 @@ class NonAssociationsResourceTest : SqsIntegrationTestBase() {
               "cellLocation": "${prisonerMerlin.cellLocation}",
               "nonAssociations": [
                 {
+                  "id": ${openNonAssociation.id},
                   "reasonCode": "${openNonAssociation.secondPrisonerReason}",
                   "reasonDescription": "${openNonAssociation.secondPrisonerReason.description}",
                   "restrictionTypeCode": "${openNonAssociation.restrictionType}",
@@ -508,6 +510,7 @@ class NonAssociationsResourceTest : SqsIntegrationTestBase() {
                   }
                 },
                 {
+                  "id": ${closedNonAssociation.id},
                   "reasonCode": "${closedNonAssociation.firstPrisonerReason}",
                   "reasonDescription": "${closedNonAssociation.firstPrisonerReason.description}",
                   "restrictionTypeCode": "${closedNonAssociation.restrictionType}",
@@ -589,6 +592,7 @@ class NonAssociationsResourceTest : SqsIntegrationTestBase() {
               "cellLocation": "${prisonerMerlin.cellLocation}",
               "nonAssociations": [
                 {
+                  "id": ${openNonAssociation.id},
                   "reasonCode": "${openNonAssociation.secondPrisonerReason}",
                   "reasonDescription": "${openNonAssociation.secondPrisonerReason.description}",
                   "restrictionTypeCode": "${openNonAssociation.restrictionType}",
@@ -611,6 +615,7 @@ class NonAssociationsResourceTest : SqsIntegrationTestBase() {
                   }
                 },
                 {
+                  "id": ${otherPrisonNonAssociation.id},
                   "reasonCode": "${otherPrisonNonAssociation.secondPrisonerReason}",
                   "reasonDescription": "${otherPrisonNonAssociation.secondPrisonerReason.description}",
                   "restrictionTypeCode": "${closedNonAssociation.restrictionType}",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/util/TestData.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/util/TestData.kt
@@ -46,4 +46,21 @@ val offenderSearchPrisoners = mapOf(
     prisonName = "Moorland",
     cellLocation = "MDI-A-2",
   ),
+  "G9012HI" to OffenderSearchPrisoner(
+    prisonerNumber = "G9012HI",
+    firstName = "Josh",
+    lastName = "Plimburkson",
+    prisonId = "MDI",
+    prisonName = "Moorland",
+    cellLocation = "MDI-A-3",
+  ),
+  // Different prison
+  "L3456MN" to OffenderSearchPrisoner(
+    prisonerNumber = "L3456MN",
+    firstName = "Edward",
+    lastName = "Lillibluprs",
+    prisonId = "FBI",
+    prisonName = "Forest Bank",
+    cellLocation = "FBI-C-2",
+  ),
 )


### PR DESCRIPTION
Improvements to `GET /prisoner/:prisonerNumber/non-associations`:
- `includeClosed` query param to also get closed non-association, default `false`, only open non-associations are returned
- `includeOtherPrisons` query param to also get non-associations with prisoners in other prisons, default `false`, by default only non-associations with prisoners in same prison [as given prisoner] are returned
- expose non-associations' `id`s
- fixes to `PrisonerNonAssociations` DTO related to closed non-associations
  -  correctly expose values related to closed non-associations
  - `closedAt` type is a `LocalDateTime`, not a string
- corrected swagger documentation for `NonAssociation`'s `id` which is always present
- added a couple more test prisoners in the OffenderSearch API test data, useful for testing filtering