### PR TITLE
NON-88: Ability to sort a prisoner non-associations

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/dto/PrisonerNonAssociations.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/dto/PrisonerNonAssociations.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.hmppsnonassociationsapi.dto
 
 import io.swagger.v3.oas.annotations.media.Schema
 import uk.gov.justice.digital.hmpps.hmppsnonassociationsapi.dto.offendersearch.OffenderSearchPrisoner
+import uk.gov.justice.digital.hmpps.hmppsnonassociationsapi.service.NonAssociationListOptions
 import java.time.LocalDateTime
 import uk.gov.justice.digital.hmpps.hmppsnonassociationsapi.jpa.NonAssociation as NonAssociationJPA
 
@@ -99,7 +100,11 @@ data class OtherPrisonerDetails(
 fun List<NonAssociationJPA>.toPrisonerNonAssociations(
   prisonerNumber: String,
   prisoners: Map<String, OffenderSearchPrisoner>,
+  options: NonAssociationListOptions,
 ): PrisonerNonAssociations {
+  val sortComparator = options.sortBy.comparator(options.sortDirection)
+  val nonAssociations = this.toNonAssociationsDetails(prisonerNumber, prisoners)
+    .sortedWith(sortComparator)
   return PrisonerNonAssociations(
     prisonerNumber = prisonerNumber,
     firstName = prisoners[prisonerNumber]!!.firstName,
@@ -107,7 +112,7 @@ fun List<NonAssociationJPA>.toPrisonerNonAssociations(
     prisonId = prisoners[prisonerNumber]!!.prisonId,
     prisonName = prisoners[prisonerNumber]!!.prisonName,
     cellLocation = prisoners[prisonerNumber]!!.cellLocation,
-    nonAssociations = this.toNonAssociationsDetails(prisonerNumber, prisoners),
+    nonAssociations = nonAssociations,
   )
 }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/resource/NonAssociationsResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/resource/NonAssociationsResource.kt
@@ -5,6 +5,7 @@ import io.swagger.v3.oas.annotations.media.Content
 import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.data.domain.Sort
 import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
 import org.springframework.security.access.prepost.PreAuthorize
@@ -24,6 +25,7 @@ import uk.gov.justice.digital.hmpps.hmppsnonassociationsapi.dto.NonAssociation
 import uk.gov.justice.digital.hmpps.hmppsnonassociationsapi.dto.PrisonerNonAssociations
 import uk.gov.justice.digital.hmpps.hmppsnonassociationsapi.service.NonAssociationListOptions
 import uk.gov.justice.digital.hmpps.hmppsnonassociationsapi.service.NonAssociationsService
+import uk.gov.justice.digital.hmpps.hmppsnonassociationsapi.service.NonAssociationsSort
 import uk.gov.justice.digital.hmpps.hmppsnonassociationsapi.services.NonAssociationDomainEventType
 
 @RestController
@@ -83,12 +85,31 @@ class NonAssociationsResource(
     )
     @RequestParam(required = false)
     includeOtherPrisons: Boolean,
+
+    @Schema(
+      description = "Sort non-associations by",
+      required = false,
+      defaultValue = "WHEN_CREATED",
+      example = "LAST_NAME",
+      allowableValues = [
+        "WHEN_CREATED",
+        "LAST_NAME",
+      ],
+    )
+    @RequestParam(required = false)
+    sortBy: NonAssociationsSort?,
+
+    @Schema(description = "Sort direction", required = false, defaultValue = "DESC", example = "DESC", allowableValues = ["ASC", "DESC"])
+    @RequestParam(required = false)
+    sortDirection: Sort.Direction?,
   ): PrisonerNonAssociations {
     return nonAssociationsService.getPrisonerNonAssociations(
       prisonerNumber,
       NonAssociationListOptions(
         includeClosed = includeClosed,
         includeOtherPrisons = includeOtherPrisons,
+        sortBy = sortBy ?: NonAssociationsSort.WHEN_CREATED,
+        sortDirection = sortDirection ?: Sort.Direction.DESC,
       ),
     )
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/resource/NonAssociationsResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/resource/NonAssociationsResource.kt
@@ -94,6 +94,7 @@ class NonAssociationsResource(
       allowableValues = [
         "WHEN_CREATED",
         "LAST_NAME",
+        "FIRST_NAME",
       ],
     )
     @RequestParam(required = false)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/resource/NonAssociationsResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/resource/NonAssociationsResource.kt
@@ -95,6 +95,7 @@ class NonAssociationsResource(
         "WHEN_CREATED",
         "LAST_NAME",
         "FIRST_NAME",
+        "PRISONER_NUMBER",
       ],
     )
     @RequestParam(required = false)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/service/NonAssociationsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/service/NonAssociationsService.kt
@@ -101,12 +101,14 @@ data class NonAssociationListOptions(
 enum class NonAssociationsSort {
   WHEN_CREATED,
   LAST_NAME,
+  FIRST_NAME,
   ;
 
   fun comparator(direction: Sort.Direction): Comparator<NonAssociationDetails> {
     return when (this) {
       WHEN_CREATED -> Comparator.comparing(NonAssociationDetails::whenCreated)
       LAST_NAME -> Comparator.comparing { nonna -> nonna.otherPrisonerDetails.lastName }
+      FIRST_NAME -> Comparator.comparing { nonna -> nonna.otherPrisonerDetails.firstName }
     }.run {
       if (direction == Sort.Direction.DESC) this.reversed() else this
     }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/service/NonAssociationsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/service/NonAssociationsService.kt
@@ -104,27 +104,11 @@ enum class NonAssociationsSort {
   ;
 
   fun comparator(direction: Sort.Direction): Comparator<NonAssociationDetails> {
-    var result = when (this) {
-      WHEN_CREATED -> CompareByWhenCreated()
-      LAST_NAME -> CompareByLastName()
+    return when (this) {
+      WHEN_CREATED -> Comparator.comparing(NonAssociationDetails::whenCreated)
+      LAST_NAME -> Comparator.comparing { nonna -> nonna.otherPrisonerDetails.lastName }
+    }.run {
+      if (direction == Sort.Direction.DESC) this.reversed() else this
     }
-
-    if (direction == Sort.Direction.DESC) {
-      result = result.reversed()
-    }
-
-    return result
-  }
-}
-
-class CompareByWhenCreated : Comparator<NonAssociationDetails> {
-  override fun compare(a: NonAssociationDetails, b: NonAssociationDetails): Int {
-    return a.whenCreated.compareTo(b.whenCreated)
-  }
-}
-
-class CompareByLastName : Comparator<NonAssociationDetails> {
-  override fun compare(a: NonAssociationDetails, b: NonAssociationDetails): Int {
-    return a.otherPrisonerDetails.lastName.compareTo(b.otherPrisonerDetails.lastName)
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/service/NonAssociationsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/service/NonAssociationsService.kt
@@ -102,6 +102,7 @@ enum class NonAssociationsSort {
   WHEN_CREATED,
   LAST_NAME,
   FIRST_NAME,
+  PRISONER_NUMBER,
   ;
 
   fun comparator(direction: Sort.Direction): Comparator<NonAssociationDetails> {
@@ -109,6 +110,7 @@ enum class NonAssociationsSort {
       WHEN_CREATED -> Comparator.comparing(NonAssociationDetails::whenCreated)
       LAST_NAME -> Comparator.comparing { nonna -> nonna.otherPrisonerDetails.lastName }
       FIRST_NAME -> Comparator.comparing { nonna -> nonna.otherPrisonerDetails.firstName }
+      PRISONER_NUMBER -> Comparator.comparing { nonna -> nonna.otherPrisonerDetails.prisonerNumber }
     }.run {
       if (direction == Sort.Direction.DESC) this.reversed() else this
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/resource/NonAssociationsResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/resource/NonAssociationsResourceTest.kt
@@ -643,6 +643,16 @@ class NonAssociationsResourceTest : SqsIntegrationTestBase() {
           false,
         )
     }
+
+    @Test
+    fun `when invalid sort values are provided responds 400 Bad Request`() {
+      val url = "/prisoner/$prisonerNumber/non-associations?sortBy=InvalidField"
+      webTestClient.get()
+        .uri(url)
+        .headers(setAuthorisation(roles = listOf("ROLE_NON_ASSOCIATIONS")))
+        .exchange()
+        .expectStatus().isBadRequest
+    }
   }
 
   private fun createNonAssociation(


### PR DESCRIPTION
- non-associations returned in order of creation by default (from newer to older)
- optional `sortBy`/`sortDirection` query params to control sorting criteria and direction
- can be sorted by creation time (default), last name or first name of the other prisoner involved in the non-association
- should be trivial to add more sorting options if/when necessary