### PR TITLE
NON-154 Add Cell ID back in as used in cell move

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/dto/prisonapi/LegacyNonAssociationDetails.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/dto/prisonapi/LegacyNonAssociationDetails.kt
@@ -19,6 +19,8 @@ data class LegacyNonAssociationDetails(
   val agencyDescription: String,
   @Schema(description = "Description of living unit (e.g. cell) the offender is assigned to.", required = false, example = "MDI-1-1-3")
   val assignedLivingUnitDescription: String?,
+  @Schema(description = "ID of living unit (e.g. cell) the offender is assigned to.", required = false, example = "113")
+  val assignedLivingUnitId: Long? = null,
   @Schema(description = "Non-associations with other prisoners", required = true)
   val nonAssociations: List<LegacyNonAssociation>,
 )
@@ -65,4 +67,6 @@ data class LegacyOffenderNonAssociation(
   val agencyDescription: String,
   @Schema(description = "Description of living unit (e.g. cell) the offender is assigned to.", required = false, example = "MDI-2-3-4")
   val assignedLivingUnitDescription: String?,
+  @Schema(description = "ID of living unit (e.g. cell) the offender is assigned to.", required = false, example = "234")
+  val assignedLivingUnitId: Long? = null,
 )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/resource/PrisonApiResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/resource/PrisonApiResourceTest.kt
@@ -24,6 +24,7 @@ class PrisonApiResourceTest : SqsIntegrationTestBase() {
       lastName = "Hall",
       agencyDescription = "Moorland (HMP & YOI)",
       assignedLivingUnitDescription = "MDI-1-1-3",
+      assignedLivingUnitId = 113,
       nonAssociations = listOf(
         LegacyNonAssociation(
           reasonCode = LegacyReason.VIC,
@@ -42,6 +43,7 @@ class PrisonApiResourceTest : SqsIntegrationTestBase() {
             reasonDescription = "Perpetrator",
             agencyDescription = "Moorland (HMP & YOI)",
             assignedLivingUnitDescription = "MDI-2-3-4",
+            assignedLivingUnitId = 234,
           ),
         ),
       ),


### PR DESCRIPTION
Will need to call `/api/locations/code/{code}` in prison API for now to get ID when feature switch is active to not use NOMIS data

Future task to bring cell move to use description rather than ID as location - offending line is https://github.com/ministryofjustice/cell-moves/blob/57cf273f503403fb51933ccdf68555a18bb4821f/backend/controllers/cellMove/selectCell.ts#L61

