### PR TITLE
NON-207: Endpoint to return non-associations involving a list of prisoners

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/jpa/repository/NonAssociationsRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/jpa/repository/NonAssociationsRepository.kt
@@ -10,6 +10,9 @@ interface NonAssociationsRepository : JpaRepository<NonAssociation, Long> {
   /** Use findAllByPrisonerNumber convenience extension function instead */
   fun findAllByFirstPrisonerNumberOrSecondPrisonerNumber(firstPrisonerNumber: String, secondPrisonerNumber: String): List<NonAssociation>
 
+  /** Use findAllByPrisonerNumbers convenience extension function instead */
+  fun findAllByFirstPrisonerNumberInOrSecondPrisonerNumberIn(p1: Collection<String>, p2: Collection<String>): List<NonAssociation>
+
   /** Use findAnyBetweenPrisonerNumbers convenience extension function instead */
   fun findAllByFirstPrisonerNumberInAndSecondPrisonerNumberIn(p1: Collection<String>, p2: Collection<String>): List<NonAssociation>
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/jpa/repository/NonAssociationsRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/jpa/repository/NonAssociationsRepository.kt
@@ -12,7 +12,7 @@ interface NonAssociationsRepository : JpaRepository<NonAssociation, Long> {
   /** Use findAllByPrisonerNumber convenience extension function instead */
   fun findAllByFirstPrisonerNumberOrSecondPrisonerNumber(firstPrisonerNumber: String, secondPrisonerNumber: String): List<NonAssociation>
 
-  /** Use findAllByPrisonerNumbers convenience extension function instead */
+  /** Use findAnyInvolvingPrisonerNumbers convenience extension function instead */
   fun findAllByFirstPrisonerNumberInOrSecondPrisonerNumberIn(p1: Collection<String>, p2: Collection<String>): List<NonAssociation>
 
   /** Use findAnyBetweenPrisonerNumbers convenience extension function instead */

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/service/NonAssociationsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/service/NonAssociationsService.kt
@@ -30,6 +30,7 @@ import uk.gov.justice.digital.hmpps.hmppsnonassociationsapi.dto.updateWith
 import uk.gov.justice.digital.hmpps.hmppsnonassociationsapi.jpa.repository.NonAssociationsRepository
 import uk.gov.justice.digital.hmpps.hmppsnonassociationsapi.jpa.repository.findAllByPrisonerNumber
 import uk.gov.justice.digital.hmpps.hmppsnonassociationsapi.jpa.repository.findAnyBetweenPrisonerNumbers
+import uk.gov.justice.digital.hmpps.hmppsnonassociationsapi.jpa.repository.findAnyInvolvingPrisonerNumbers
 import java.time.Clock
 import java.time.LocalDateTime
 import kotlin.jvm.optionals.getOrNull
@@ -95,6 +96,17 @@ class NonAssociationsService(
     inclusion: NonAssociationListInclusion = NonAssociationListInclusion.OPEN_ONLY,
   ): List<NonAssociationDTO> {
     return nonAssociationsRepository.findAnyBetweenPrisonerNumbers(prisonerNumbers, inclusion)
+      .map { it.toDto() }
+  }
+
+  /**
+   * Returns all non-associations involving any of the provided prisoners
+   */
+  fun getAnyInvolving(
+    prisonerNumbers: Collection<String>,
+    inclusion: NonAssociationListInclusion = NonAssociationListInclusion.OPEN_ONLY,
+  ): List<NonAssociationDTO> {
+    return nonAssociationsRepository.findAnyInvolvingPrisonerNumbers(prisonerNumbers, inclusion)
       .map { it.toDto() }
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/jpa/repository/NonAssociationsRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/jpa/repository/NonAssociationsRepositoryTest.kt
@@ -59,6 +59,32 @@ class NonAssociationsRepositoryTest : TestBase() {
     }
   }
 
+  @Test
+  fun findAllByFirstPrisonerNumberInOrSecondPrisonerNumberIn() {
+    repository.saveAll(
+      listOf(
+        nonAssociation("A1234CB", "X0123BB"),
+        nonAssociation("D5678EF", "A1234BC", true), // returned
+        nonAssociation("A1234BC", "D5678EG"),
+        nonAssociation("X0123AA", "X0123BB"),
+        nonAssociation("A1234BC", "G0011AA"), // returned
+        nonAssociation("G0022BB", "A1234BC"),
+      ),
+    )
+
+    val prisonerNumbers = listOf("D5678EF", "G0011AA")
+    val nonAssociations = repository.findAllByFirstPrisonerNumberInOrSecondPrisonerNumberIn(
+      prisonerNumbers,
+      prisonerNumbers,
+    )
+
+    assertThat(nonAssociations).hasSize(2)
+    assertThat(nonAssociations).allMatch { nonna ->
+      // All non-associations involve at least one of the required prisoners
+      prisonerNumbers.contains(nonna.firstPrisonerNumber) || prisonerNumbers.contains(nonna.secondPrisonerNumber)
+    }
+  }
+
   @Nested
   inner class findAnyBetweenPrisonerNumbers() {
     @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/jpa/repository/NonAssociationsRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/jpa/repository/NonAssociationsRepositoryTest.kt
@@ -196,7 +196,7 @@ class NonAssociationsRepositoryTest : TestBase() {
       assertThat(nonAssociations).hasSize(4)
       assertThat(nonAssociations).allMatch {
         it.isOpen &&
-        (prisonerNumbers.contains(it.firstPrisonerNumber) || prisonerNumbers.contains(it.secondPrisonerNumber))
+          (prisonerNumbers.contains(it.firstPrisonerNumber) || prisonerNumbers.contains(it.secondPrisonerNumber))
       }
       val nonAssociationPairs = nonAssociations.map { listOf(it.firstPrisonerNumber, it.secondPrisonerNumber) }
       assertThat(nonAssociationPairs).isEqualTo(
@@ -230,7 +230,7 @@ class NonAssociationsRepositoryTest : TestBase() {
       assertThat(nonAssociations).hasSize(3)
       assertThat(nonAssociations).allMatch {
         it.isClosed &&
-        (prisonerNumbers.contains(it.firstPrisonerNumber) || prisonerNumbers.contains(it.secondPrisonerNumber))
+          (prisonerNumbers.contains(it.firstPrisonerNumber) || prisonerNumbers.contains(it.secondPrisonerNumber))
       }
       val nonAssociationPairs = nonAssociations.map { listOf(it.firstPrisonerNumber, it.secondPrisonerNumber) }
       assertThat(nonAssociationPairs).isEqualTo(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/resource/NonAssociationsResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/resource/NonAssociationsResourceTest.kt
@@ -2156,6 +2156,328 @@ class NonAssociationsResourceTest : SqsIntegrationTestBase() {
     }
   }
 
+  @Nested
+  inner class `Get non-associations involving a group of prisoners` {
+    private val prisonerJohnNumber = "A1234BC"
+    private val prisonerMerlinNumber = "D5678EF"
+
+    private val urlPath = "/non-associations/involving"
+
+    @Test
+    fun `without a valid token responds 401 Unauthorized`() {
+      webTestClient.post()
+        .uri(urlPath)
+        .bodyValue(listOf(prisonerJohnNumber, prisonerMerlinNumber))
+        .exchange()
+        .expectStatus()
+        .isUnauthorized
+    }
+
+    @Test
+    fun `without the correct role responds 403 Forbidden`() {
+      webTestClient.post()
+        .uri(urlPath)
+        .headers(setAuthorisation(roles = listOf("WRONG_ROLE")))
+        .bodyValue(listOf(prisonerJohnNumber, prisonerMerlinNumber))
+        .exchange()
+        .expectStatus()
+        .isForbidden
+    }
+
+    @Test
+    fun `without one or more distinct prisoner numbers responds with 400 Bad Request`() {
+      // no prisoners provided
+      webTestClient.post()
+        .uri(urlPath)
+        .headers(setAuthorisation(roles = listOf("ROLE_NON_ASSOCIATIONS")))
+        .exchange()
+        .expectStatus()
+        .isBadRequest
+
+      // empty list of prisoners provided
+      webTestClient.post()
+        .uri(urlPath)
+        .headers(setAuthorisation(roles = listOf("ROLE_NON_ASSOCIATIONS")))
+        .bodyValue(emptyList<String>())
+        .exchange()
+        .expectStatus()
+        .isBadRequest
+
+      // 1 blank prisoner provided
+      webTestClient.post()
+        .uri(urlPath)
+        .headers(setAuthorisation(roles = listOf("ROLE_NON_ASSOCIATIONS")))
+        .bodyValue(listOf(""))
+        .exchange()
+        .expectStatus()
+        .isBadRequest
+    }
+
+    @Test
+    fun `when there are no non-associations involving the prisoners`() {
+      createNonAssociation("A0011AA", "D4444DD")
+
+      webTestClient.post()
+        .uri(urlPath)
+        .headers(setAuthorisation(roles = listOf("ROLE_NON_ASSOCIATIONS")))
+        .bodyValue(listOf(prisonerJohnNumber, prisonerMerlinNumber))
+        .exchange()
+        .expectStatus().isOk
+        .expectBody().json("[]", true)
+    }
+
+    @Test
+    fun `when there are non-associations involving the prisoners`() {
+      createNonAssociation("D4444DD", prisonerJohnNumber)
+      createNonAssociation(prisonerMerlinNumber, "C3333CC", isClosed = true)
+
+      webTestClient.post()
+        .uri(urlPath)
+        .headers(setAuthorisation(roles = listOf("ROLE_NON_ASSOCIATIONS")))
+        .bodyValue(listOf(prisonerJohnNumber, prisonerMerlinNumber))
+        .exchange()
+        .expectStatus().isOk
+        .expectBody().json(
+          // language=json
+          """
+          [
+            {
+              "firstPrisonerNumber": "D4444DD",
+              "firstPrisonerRole": "VICTIM",
+              "firstPrisonerRoleDescription": "Victim",
+              "secondPrisonerNumber": "$prisonerJohnNumber",
+              "secondPrisonerRole": "PERPETRATOR",
+              "secondPrisonerRoleDescription": "Perpetrator",
+              "reason": "BULLYING",
+              "reasonDescription": "Bullying",
+              "restrictionType": "CELL",
+              "restrictionTypeDescription": "Cell only",
+              "comment": "They keep fighting",
+              "authorisedBy": "USER_1",
+              "updatedBy": "A_TEST_USER",
+              "isClosed": false,
+              "closedBy": null,
+              "closedReason": null,
+              "closedAt": null
+            }
+          ]
+          """,
+          false,
+        )
+    }
+
+    @Test
+    fun `when there are non-associations involving the prisoners including open and closed`() {
+      createNonAssociation("D4444DD", prisonerJohnNumber)
+      createNonAssociation(prisonerMerlinNumber, "C3333CC", isClosed = true)
+
+      webTestClient.post()
+        .uri {
+          it.path(urlPath)
+            .queryParam("includeClosed", true)
+            .build()
+        }
+        .headers(setAuthorisation(roles = listOf("ROLE_NON_ASSOCIATIONS")))
+        .bodyValue(listOf(prisonerJohnNumber, prisonerMerlinNumber))
+        .exchange()
+        .expectStatus().isOk
+        .expectBody().json(
+          // language=json
+          """
+          [
+            {
+              "firstPrisonerNumber": "D4444DD",
+              "firstPrisonerRole": "VICTIM",
+              "firstPrisonerRoleDescription": "Victim",
+              "secondPrisonerNumber": "$prisonerJohnNumber",
+              "secondPrisonerRole": "PERPETRATOR",
+              "secondPrisonerRoleDescription": "Perpetrator",
+              "reason": "BULLYING",
+              "reasonDescription": "Bullying",
+              "restrictionType": "CELL",
+              "restrictionTypeDescription": "Cell only",
+              "comment": "They keep fighting",
+              "authorisedBy": "USER_1",
+              "updatedBy": "A_TEST_USER",
+              "isClosed": false,
+              "closedBy": null,
+              "closedReason": null,
+              "closedAt": null
+            },
+            {
+              "firstPrisonerNumber": "$prisonerMerlinNumber",
+              "firstPrisonerRole": "VICTIM",
+              "firstPrisonerRoleDescription": "Victim",
+              "secondPrisonerNumber": "C3333CC",
+              "secondPrisonerRole": "PERPETRATOR",
+              "secondPrisonerRoleDescription": "Perpetrator",
+              "reason": "BULLYING",
+              "reasonDescription": "Bullying",
+              "restrictionType": "CELL",
+              "restrictionTypeDescription": "Cell only",
+              "comment": "They keep fighting",
+              "authorisedBy": "USER_1",
+              "updatedBy": "A_TEST_USER",
+              "isClosed": true,
+              "closedBy": "CLOSE_USER",
+              "closedReason": "They're friends now"
+            }
+          ]
+          """,
+          false,
+        )
+    }
+
+    @Test
+    fun `when there are non-associations involving the prisoners including only closed`() {
+      createNonAssociation("D4444DD", prisonerJohnNumber)
+      createNonAssociation(prisonerMerlinNumber, "C3333CC", isClosed = true)
+
+      webTestClient.post()
+        .uri {
+          it.path(urlPath)
+            .queryParam("includeOpen", false)
+            .queryParam("includeClosed", true)
+            .build()
+        }
+        .headers(setAuthorisation(roles = listOf("ROLE_NON_ASSOCIATIONS")))
+        .bodyValue(listOf(prisonerJohnNumber, prisonerMerlinNumber))
+        .exchange()
+        .expectStatus().isOk
+        .expectBody().json(
+          // language=json
+          """
+          [
+            {
+              "firstPrisonerNumber": "$prisonerMerlinNumber",
+              "firstPrisonerRole": "VICTIM",
+              "firstPrisonerRoleDescription": "Victim",
+              "secondPrisonerNumber": "C3333CC",
+              "secondPrisonerRole": "PERPETRATOR",
+              "secondPrisonerRoleDescription": "Perpetrator",
+              "reason": "BULLYING",
+              "reasonDescription": "Bullying",
+              "restrictionType": "CELL",
+              "restrictionTypeDescription": "Cell only",
+              "comment": "They keep fighting",
+              "authorisedBy": "USER_1",
+              "updatedBy": "A_TEST_USER",
+              "isClosed": true,
+              "closedBy": "CLOSE_USER",
+              "closedReason": "They're friends now"
+            }
+          ]
+          """,
+          false,
+        )
+    }
+
+    @Test
+    fun `when there are non-associations involving the prisoners but neither open nor closed were included`() {
+      createNonAssociation()
+      createNonAssociation(isClosed = true)
+
+      webTestClient.post()
+        .uri {
+          it.path(urlPath)
+            .queryParam("includeOpen", false)
+            .queryParam("includeClosed", false)
+            .build()
+        }
+        .headers(setAuthorisation(roles = listOf("ROLE_NON_ASSOCIATIONS")))
+        .bodyValue(listOf(prisonerJohnNumber, prisonerMerlinNumber))
+        .exchange()
+        .expectStatus().isBadRequest
+    }
+
+    @Test
+    fun `when non-associations are requested involving more than 2 prisoners`() {
+      // language=mermaid
+      """
+      classDiagram
+        A0000AA -- A1111AA
+        A0000AA -- A2222AA
+        A2222AA -- A3333AA
+        A1111AA -- A4444AA
+        A4444AA -- A2222AA : closed
+      """
+      createNonAssociation("A0000AA", "A1111AA") // never returned
+      createNonAssociation("A0000AA", "A2222AA") // returned
+      createNonAssociation("A2222AA", "A3333AA") // returned
+      createNonAssociation("A1111AA", "A4444AA") // returned
+      createNonAssociation("A4444AA", "A2222AA", true) // returned when closed is included
+
+      webTestClient.post()
+        .uri(urlPath)
+        .headers(setAuthorisation(roles = listOf("ROLE_NON_ASSOCIATIONS")))
+        .bodyValue(listOf("A2222AA", "A4444AA", "B0000BB"))
+        .exchange()
+        .expectStatus().isOk
+        .expectBody().json(
+          // language=json
+          """
+          [
+            {
+              "firstPrisonerNumber": "A0000AA",
+              "secondPrisonerNumber": "A2222AA",
+              "isClosed": false
+            },
+            {
+              "firstPrisonerNumber": "A2222AA",
+              "secondPrisonerNumber": "A3333AA",
+              "isClosed": false
+            },
+            {
+              "firstPrisonerNumber": "A1111AA",
+              "secondPrisonerNumber": "A4444AA",
+              "isClosed": false
+            }
+          ]
+          """,
+          false,
+        )
+
+      webTestClient.post()
+        .uri {
+          it.path(urlPath)
+            .queryParam("includeClosed", true)
+            .build()
+        }
+        .headers(setAuthorisation(roles = listOf("ROLE_NON_ASSOCIATIONS")))
+        .bodyValue(listOf("A2222AA", "A4444AA", "B0000BB"))
+        .exchange()
+        .expectStatus().isOk
+        .expectBody().json(
+          // language=json
+          """
+          [
+            {
+              "firstPrisonerNumber": "A0000AA",
+              "secondPrisonerNumber": "A2222AA",
+              "isClosed": false
+            },
+            {
+              "firstPrisonerNumber": "A2222AA",
+              "secondPrisonerNumber": "A3333AA",
+              "isClosed": false
+            },
+            {
+              "firstPrisonerNumber": "A1111AA",
+              "secondPrisonerNumber": "A4444AA",
+              "isClosed": false
+            },
+            {
+              "firstPrisonerNumber": "A4444AA",
+              "secondPrisonerNumber": "A2222AA",
+              "isClosed": true
+            }
+          ]
+          """,
+          false,
+        )
+    }
+  }
+
   private fun createNonAssociation(
     firstPrisonerNumber: String = "A1234BC",
     secondPrisonerNumber: String = "D5678EF",


### PR DESCRIPTION
Similar to the `POST /non-associations/between` endpoint but returns non-associations as long as any of the involved prisoners was part of the request list.

Like the "between" endpoint returns only open non-associations by default but it's possible to request for only closed or all non-associations.