### PR TITLE
NON-215: Don't send duplicated prisoner numbers to Offender Search API

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/service/NonAssociationsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/service/NonAssociationsService.kt
@@ -237,9 +237,9 @@ class NonAssociationsService(
   }
 
   private fun filterByPrisonId(nonAssociations: List<NonAssociationJPA>, prisonId: String): List<NonAssociationJPA> {
-    val prisonerNumbers = nonAssociations.map { nonna ->
+    val prisonerNumbers = nonAssociations.flatMap { nonna ->
       listOf(nonna.firstPrisonerNumber, nonna.secondPrisonerNumber)
-    }.flatten()
+    }
     val prisoners = offenderSearch.searchByPrisonerNumbers(prisonerNumbers)
 
     return nonAssociations.filter { nonna ->

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/service/NonAssociationsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/service/NonAssociationsService.kt
@@ -178,6 +178,8 @@ class NonAssociationsService(
     var nonAssociations = nonAssociationsRepository.findAllByPrisonerNumber(prisonerNumber)
 
     // load all prisoner mentioned in any non-association
+    // note that we always want to retrieve the information about the key
+    // prisoner, even if they don't have any non-associations
     val prisonerNumbers = nonAssociations.flatMapTo(mutableSetOf(prisonerNumber)) {
       listOf(it.firstPrisonerNumber, it.secondPrisonerNumber)
     }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/service/OffenderSearchService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/service/OffenderSearchService.kt
@@ -26,7 +26,7 @@ class OffenderSearchService(
     prisonerNumbers: Collection<String>,
     useClientCredentials: Boolean = true,
   ): Map<String, OffenderSearchPrisoner> {
-    val requestBody = mapOf("prisonerNumbers" to prisonerNumbers)
+    val requestBody = mapOf("prisonerNumbers" to prisonerNumbers.toSet())
 
     val foundPrisoners = getClient(useClientCredentials)
       .post()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/integration/wiremock/OffenderSearchMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/integration/wiremock/OffenderSearchMockServer.kt
@@ -30,7 +30,7 @@ class OffenderSearchMockServer : WireMockServer(WIREMOCK_PORT) {
     prisonerNumbers: List<String>,
     prisoners: List<OffenderSearchPrisoner>,
   ) {
-    val requestBody = mapper.writeValueAsString(mapOf("prisonerNumbers" to prisonerNumbers))
+    val requestBody = mapper.writeValueAsString(mapOf("prisonerNumbers" to prisonerNumbers.toSet()))
 
     stubFor(
       post("/prisoner-search/prisoner-numbers")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/resource/NonAssociationsResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/resource/NonAssociationsResourceTest.kt
@@ -2217,7 +2217,6 @@ class NonAssociationsResourceTest : SqsIntegrationTestBase() {
         prisonerMerlin.prisonerNumber,
         prisonerJosh.prisonerNumber,
         prisonerEdward.prisonerNumber,
-        prisonerJosh.prisonerNumber,
       )
       val prisoners = listOf(
         prisonerMerlin,
@@ -2596,7 +2595,6 @@ class NonAssociationsResourceTest : SqsIntegrationTestBase() {
         prisonerMerlin.prisonerNumber,
         prisonerJosh.prisonerNumber,
         prisonerEdward.prisonerNumber,
-        prisonerJosh.prisonerNumber,
       )
       val prisoners = listOf(
         prisonerMerlin,


### PR DESCRIPTION
Mainly that plus a couple of other tweaks:
- use `flatMap()` instead of `map()` + `flatten()`
- added a note in `getPrisonerNonAssociations()` on why in that method we use `flatMapTo()` instead of `flatMap()` to be sure the "key" prisoner's prisoner number is always in the request to Offender Search API (a test covers that)