### PR TITLE
NON-193: Allow sorting non-associations by more options

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/dto/ListOptions.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/dto/ListOptions.kt
@@ -49,6 +49,9 @@ data class NonAssociationListOptions(
         NonAssociationsSort.LAST_NAME -> compareBy { nonna -> nonna.otherPrisonerDetails.lastName }
         NonAssociationsSort.FIRST_NAME -> compareBy { nonna -> nonna.otherPrisonerDetails.firstName }
         NonAssociationsSort.PRISONER_NUMBER -> compareBy { nonna -> nonna.otherPrisonerDetails.prisonerNumber }
+        NonAssociationsSort.PRISON_ID -> compareBy { nonna -> nonna.otherPrisonerDetails.prisonId }
+        NonAssociationsSort.PRISON_NAME -> compareBy { nonna -> nonna.otherPrisonerDetails.prisonName }
+        NonAssociationsSort.CELL_LOCATION -> compareBy { nonna -> nonna.otherPrisonerDetails.cellLocation }
       }.run {
         if (sortDirection == Sort.Direction.DESC) reversed() else this
       }
@@ -61,4 +64,7 @@ enum class NonAssociationsSort(val defaultSortDirection: Sort.Direction) {
   LAST_NAME(Sort.Direction.ASC),
   FIRST_NAME(Sort.Direction.ASC),
   PRISONER_NUMBER(Sort.Direction.ASC),
+  PRISON_ID(Sort.Direction.ASC),
+  PRISON_NAME(Sort.Direction.ASC),
+  CELL_LOCATION(Sort.Direction.ASC),
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/resource/NonAssociationsResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/resource/NonAssociationsResource.kt
@@ -78,7 +78,7 @@ class NonAssociationsResource(
       ),
     ],
   )
-  fun getDetailsByPrisonerNumber(
+  fun getPrisonerNonAssociations(
     @Schema(description = "The offender prisoner number", example = "A1234BC", required = true)
     @PathVariable
     prisonerNumber: String,
@@ -121,6 +121,9 @@ class NonAssociationsResource(
         "LAST_NAME",
         "FIRST_NAME",
         "PRISONER_NUMBER",
+        "PRISON_ID",
+        "PRISON_NAME",
+        "CELL_LOCATION",
       ],
     )
     @RequestParam(required = false)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/resource/NonAssociationsResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/resource/NonAssociationsResourceTest.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.hmppsnonassociationsapi.resource
 
 import com.fasterxml.jackson.core.type.TypeReference
+import io.swagger.v3.oas.annotations.media.Schema
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
@@ -14,6 +15,7 @@ import uk.gov.justice.digital.hmpps.hmppsnonassociationsapi.dto.CloseNonAssociat
 import uk.gov.justice.digital.hmpps.hmppsnonassociationsapi.dto.DeleteNonAssociationRequest
 import uk.gov.justice.digital.hmpps.hmppsnonassociationsapi.dto.LegacyReason
 import uk.gov.justice.digital.hmpps.hmppsnonassociationsapi.dto.NonAssociation
+import uk.gov.justice.digital.hmpps.hmppsnonassociationsapi.dto.NonAssociationsSort
 import uk.gov.justice.digital.hmpps.hmppsnonassociationsapi.dto.PatchNonAssociationRequest
 import uk.gov.justice.digital.hmpps.hmppsnonassociationsapi.dto.PrisonerNonAssociations
 import uk.gov.justice.digital.hmpps.hmppsnonassociationsapi.dto.Reason
@@ -1325,8 +1327,16 @@ class NonAssociationsResourceTest : SqsIntegrationTestBase() {
 
   @Nested
   inner class `Get non-associations lists for a prisoner` {
-
     private val prisonerNumber = "A1234BC"
+
+    @Test
+    fun `list endpoint documents all sorting options`() {
+      val sortByParameter = NonAssociationsResource::getPrisonerNonAssociations.parameters.find { it.name == "sortBy" }!!
+      val schemaAnnotation = sortByParameter.annotations.filterIsInstance<Schema>()[0]
+      assertThat(NonAssociationsSort.entries).allMatch {
+        schemaAnnotation.allowableValues.contains(it.name)
+      }
+    }
 
     @Test
     fun `without a valid token responds 401 Unauthorized`() {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/service/NonAssociationsServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/service/NonAssociationsServiceTest.kt
@@ -22,6 +22,7 @@ import uk.gov.justice.digital.hmpps.hmppsnonassociationsapi.util.createNonAssoci
 import uk.gov.justice.digital.hmpps.hmppsnonassociationsapi.util.genNonAssociation
 import uk.gov.justice.digital.hmpps.hmppsnonassociationsapi.util.offenderSearchPrisoners
 import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
 import uk.gov.justice.digital.hmpps.hmppsnonassociationsapi.dto.NonAssociation as NonAssociationDTO
 import uk.gov.justice.digital.hmpps.hmppsnonassociationsapi.jpa.NonAssociation as NonAssociationJPA
 
@@ -80,34 +81,36 @@ class NonAssociationsServiceTest {
 
   @Nested
   inner class `sorting of prisoner non-associations` {
-    private val otherPrisoners = listOf("D5678EF", "G9012HI", "L3456MN")
+    private val keyPrisoner = "A1234BC"
+    private val otherPrisoners = offenderSearchPrisoners.keys.filter { it != keyPrisoner }
 
     @BeforeEach
     fun setUp() {
-      whenever(offenderSearchService.searchByPrisonerNumbers(any(), any())).thenReturn(offenderSearchPrisoners)
-    }
-
-    private infix fun NonAssociationListOptions.assertSortsNonAssociationsBy(comparator: Comparator<PrisonerNonAssociation>) {
-      val prisonerNonAssociations = service.getPrisonerNonAssociations("A1234BC", this)
-      assertThat(prisonerNonAssociations.nonAssociations).isSortedAccordingTo(comparator)
-    }
-
-    @Test
-    fun `by default order`() {
       var createTime = LocalDateTime.now(TestBase.clock)
       val nonAssociations = otherPrisoners.mapIndexed { index, otherPrisoner ->
         createTime = createTime.plusDays(1)
         genNonAssociation(
           id = index.toLong(),
-          firstPrisonerNumber = "A1234BC",
+          firstPrisonerNumber = keyPrisoner,
           secondPrisonerNumber = otherPrisoner,
           createTime = createTime,
         )
       }
-      whenever(nonAssociationsRepository.findAllByFirstPrisonerNumberOrSecondPrisonerNumber(eq("A1234BC"), eq("A1234BC")))
-        .thenReturn(nonAssociations)
 
-      NonAssociationListOptions() assertSortsNonAssociationsBy { n1, n2 ->
+      whenever(offenderSearchService.searchByPrisonerNumbers(any(), any())).thenReturn(offenderSearchPrisoners)
+      whenever(nonAssociationsRepository.findAllByFirstPrisonerNumberOrSecondPrisonerNumber(eq(keyPrisoner), eq(keyPrisoner)))
+        .thenReturn(nonAssociations)
+    }
+
+    private infix fun NonAssociationListOptions.assertSortsNonAssociationsBy(comparator: Comparator<PrisonerNonAssociation>) {
+      val prisonerNonAssociations = service.getPrisonerNonAssociations(keyPrisoner, this)
+      assertThat(prisonerNonAssociations.nonAssociations).isSortedAccordingTo(comparator)
+    }
+
+    @Test
+    fun `by default order`() {
+      val defaultListOptions = NonAssociationListOptions()
+      defaultListOptions assertSortsNonAssociationsBy { n1, n2 ->
         // descending by created date
         n2.whenCreated.compareTo(n1.whenCreated)
       }
@@ -115,22 +118,8 @@ class NonAssociationsServiceTest {
 
     @Test
     fun `by updated date in default direction`() {
-      var createTime = LocalDateTime.now(TestBase.clock)
-      val nonAssociations = otherPrisoners.mapIndexed { index, otherPrisoner ->
-        createTime = createTime.plusDays(1)
-        genNonAssociation(
-          id = index.toLong(),
-          firstPrisonerNumber = "A1234BC",
-          secondPrisonerNumber = otherPrisoner,
-          createTime = createTime,
-        )
-      }
-      whenever(nonAssociationsRepository.findAllByFirstPrisonerNumberOrSecondPrisonerNumber(eq("A1234BC"), eq("A1234BC")))
-        .thenReturn(nonAssociations)
-
-      NonAssociationListOptions(
-        sortBy = NonAssociationsSort.WHEN_UPDATED,
-      ) assertSortsNonAssociationsBy { n1, n2 ->
+      val listOptions = NonAssociationListOptions(sortBy = NonAssociationsSort.WHEN_UPDATED)
+      listOptions assertSortsNonAssociationsBy { n1, n2 ->
         // descending by updated date
         n2.whenUpdated.compareTo(n1.whenUpdated)
       }
@@ -138,23 +127,9 @@ class NonAssociationsServiceTest {
 
     @Test
     fun `by updated date in specified direction`() {
-      var createTime = LocalDateTime.now(TestBase.clock)
-      val nonAssociations = otherPrisoners.mapIndexed { index, otherPrisoner ->
-        createTime = createTime.plusDays(1)
-        genNonAssociation(
-          id = index.toLong(),
-          firstPrisonerNumber = "A1234BC",
-          secondPrisonerNumber = otherPrisoner,
-          createTime = createTime,
-        )
-      }
-      whenever(nonAssociationsRepository.findAllByFirstPrisonerNumberOrSecondPrisonerNumber(eq("A1234BC"), eq("A1234BC")))
-        .thenReturn(nonAssociations)
-
-      NonAssociationListOptions(
-        sortBy = NonAssociationsSort.WHEN_UPDATED,
-        sortDirection = Sort.Direction.ASC,
-      ) assertSortsNonAssociationsBy { n1, n2 ->
+      val listOptions =
+        NonAssociationListOptions(sortBy = NonAssociationsSort.WHEN_UPDATED, sortDirection = Sort.Direction.ASC)
+      listOptions assertSortsNonAssociationsBy { n1, n2 ->
         // ascending by updated date
         n1.whenCreated.compareTo(n2.whenCreated)
       }
@@ -162,19 +137,8 @@ class NonAssociationsServiceTest {
 
     @Test
     fun `by prisoner number in default direction`() {
-      val nonAssociations = otherPrisoners.mapIndexed { index, otherPrisoner ->
-        genNonAssociation(
-          id = index.toLong(),
-          firstPrisonerNumber = "A1234BC",
-          secondPrisonerNumber = otherPrisoner,
-        )
-      }
-      whenever(nonAssociationsRepository.findAllByFirstPrisonerNumberOrSecondPrisonerNumber(eq("A1234BC"), eq("A1234BC")))
-        .thenReturn(nonAssociations)
-
-      NonAssociationListOptions(
-        sortBy = NonAssociationsSort.PRISONER_NUMBER,
-      ) assertSortsNonAssociationsBy { n1, n2 ->
+      val listOptions = NonAssociationListOptions(sortBy = NonAssociationsSort.PRISONER_NUMBER)
+      listOptions assertSortsNonAssociationsBy { n1, n2 ->
         // ascending by updated date
         n1.otherPrisonerDetails.prisonerNumber.compareTo(n2.otherPrisonerDetails.prisonerNumber)
       }
@@ -182,22 +146,39 @@ class NonAssociationsServiceTest {
 
     @Test
     fun `by prisoner number in specified direction`() {
-      val nonAssociations = otherPrisoners.mapIndexed { index, otherPrisoner ->
-        genNonAssociation(
-          id = index.toLong(),
-          firstPrisonerNumber = "A1234BC",
-          secondPrisonerNumber = otherPrisoner,
-        )
-      }
-      whenever(nonAssociationsRepository.findAllByFirstPrisonerNumberOrSecondPrisonerNumber(eq("A1234BC"), eq("A1234BC")))
-        .thenReturn(nonAssociations)
-
-      NonAssociationListOptions(
-        sortBy = NonAssociationsSort.PRISONER_NUMBER,
-        sortDirection = Sort.Direction.DESC,
-      ) assertSortsNonAssociationsBy { n1, n2 ->
+      val listOptions = NonAssociationListOptions(sortBy = NonAssociationsSort.PRISONER_NUMBER, sortDirection = Sort.Direction.DESC)
+      listOptions assertSortsNonAssociationsBy { n1, n2 ->
         // descending by updated date
         n2.otherPrisonerDetails.prisonerNumber.compareTo(n1.otherPrisonerDetails.prisonerNumber)
+      }
+    }
+
+    @Test
+    fun `by all sort-by options`() {
+      val dtFormat = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss")
+
+      NonAssociationsSort.entries.forEach { sortBy ->
+        val getter: (PrisonerNonAssociation) -> String = when (sortBy) {
+          NonAssociationsSort.WHEN_CREATED -> { n -> n.whenCreated.format(dtFormat) }
+          NonAssociationsSort.WHEN_UPDATED -> { n -> n.whenUpdated.format(dtFormat) }
+          NonAssociationsSort.LAST_NAME -> { n -> n.otherPrisonerDetails.lastName }
+          NonAssociationsSort.FIRST_NAME -> { n -> n.otherPrisonerDetails.firstName }
+          NonAssociationsSort.PRISONER_NUMBER -> { n -> n.otherPrisonerDetails.prisonerNumber }
+          NonAssociationsSort.PRISON_ID -> { n -> n.otherPrisonerDetails.prisonId }
+          NonAssociationsSort.PRISON_NAME -> { n -> n.otherPrisonerDetails.prisonName }
+          NonAssociationsSort.CELL_LOCATION -> { n -> n.otherPrisonerDetails.cellLocation!! }
+        }
+        Sort.Direction.entries.forEach { sortDirection ->
+          val listOptions = NonAssociationListOptions(sortBy = sortBy, sortDirection = sortDirection)
+          listOptions assertSortsNonAssociationsBy { n1, n2 ->
+            val p1 = getter(n1)
+            val p2 = getter(n2)
+            when (sortDirection) {
+              Sort.Direction.ASC -> p1.compareTo(p2)
+              Sort.Direction.DESC -> p2.compareTo(p1)
+            }
+          }
+        }
       }
     }
   }


### PR DESCRIPTION
Even though the staff-facing site will have to sort non-association lists internally, we might as well have the same options in the api to prevent confusion.