### PR TITLE
NON-233 When duplicate detected - raise 409 response instead of 400 

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/config/HmppsNonAssociationsApiExceptionHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/config/HmppsNonAssociationsApiExceptionHandler.kt
@@ -6,6 +6,7 @@ import org.apache.commons.lang3.StringUtils
 import org.slf4j.LoggerFactory
 import org.springframework.http.HttpStatus
 import org.springframework.http.HttpStatus.BAD_REQUEST
+import org.springframework.http.HttpStatus.CONFLICT
 import org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR
 import org.springframework.http.ResponseEntity
 import org.springframework.http.converter.HttpMessageNotReadableException
@@ -203,10 +204,10 @@ class HmppsNonAssociationsApiExceptionHandler {
   fun handleOpenNonAssociationAlreadyExistsException(e: OpenNonAssociationAlreadyExistsException): ResponseEntity<ErrorResponse?>? {
     log.debug("Non-association already exists for these prisoners that is open: {}", e.message)
     return ResponseEntity
-      .status(BAD_REQUEST)
+      .status(CONFLICT)
       .body(
         ErrorResponse(
-          status = BAD_REQUEST,
+          status = CONFLICT,
           errorCode = ErrorCode.OpenNonAssociationAlreadyExist,
           userMessage = "Non-association already exists for these prisoners that is open: ${e.message}",
           developerMessage = e.message,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/resource/NonAssociationsResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/resource/NonAssociationsResourceTest.kt
@@ -320,7 +320,7 @@ class NonAssociationsResourceTest : SqsIntegrationTestBase() {
         .header("Content-Type", "application/json")
         .bodyValue(jsonString(request))
         .exchange()
-        .expectStatus().isBadRequest
+        .expectStatus().isEqualTo(409)
     }
 
     @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/resource/SyncAndMigrateResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/resource/SyncAndMigrateResourceTest.kt
@@ -132,7 +132,7 @@ class SyncAndMigrateResourceTest : SqsIntegrationTestBase() {
         .header("Content-Type", "application/json")
         .bodyValue(jsonString(request))
         .exchange()
-        .expectStatus().isBadRequest
+        .expectStatus().isEqualTo(409)
     }
 
     @Test
@@ -361,7 +361,7 @@ class SyncAndMigrateResourceTest : SqsIntegrationTestBase() {
         .header("Content-Type", "application/json")
         .bodyValue(jsonString(request))
         .exchange()
-        .expectStatus().isBadRequest
+        .expectStatus().isEqualTo(409)
     }
 
     @Test


### PR DESCRIPTION
Delete only occurs where the prisoner numbers are the same.