### PR TITLE
Gradle tasks to connect a local port to RDS or Redis in Cloud Platform and to reveal kubernetes secrets

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,3 +1,8 @@
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+import uk.gov.justice.digital.hmpps.gradle.PortForwardRDSTask
+import uk.gov.justice.digital.hmpps.gradle.PortForwardRedisTask
+import uk.gov.justice.digital.hmpps.gradle.RevealSecretsTask
+
 plugins {
   id("uk.gov.justice.hmpps.gradle-spring-boot") version "5.4.1"
   kotlin("plugin.spring") version "1.9.10"
@@ -48,13 +53,25 @@ dependencies {
 }
 
 java {
-  toolchain.languageVersion.set(JavaLanguageVersion.of(20))
+  toolchain.languageVersion = JavaLanguageVersion.of(20)
+}
+
+tasks.register<PortForwardRDSTask>("portForwardRDS") {
+  namespacePrefix = "hmpps-non-associations"
+}
+
+tasks.register<PortForwardRedisTask>("portForwardRedis") {
+  namespacePrefix = "hmpps-non-associations"
+}
+
+tasks.register<RevealSecretsTask>("revealSecrets") {
+  namespacePrefix = "hmpps-non-associations"
 }
 
 tasks {
-  withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
+  withType<KotlinCompile> {
     kotlinOptions {
-      jvmTarget = "20"
+      jvmTarget = JavaVersion.VERSION_20.toString()
     }
   }
 }

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -1,0 +1,23 @@
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
+group = "uk.gov.justice.digital.hmpps.gradle"
+version = "1.0-SNAPSHOT"
+description = "Custom gradle tasks"
+
+plugins {
+  kotlin("jvm") version "1.9.10"
+}
+
+repositories {
+  mavenCentral()
+}
+
+java {
+  toolchain.languageVersion = JavaLanguageVersion.of(20)
+}
+
+tasks {
+  withType<KotlinCompile> {
+    kotlinOptions.jvmTarget = JavaVersion.VERSION_20.toString()
+  }
+}

--- a/buildSrc/settings.gradle.kts
+++ b/buildSrc/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = "hmpps-gradle-tasks"

--- a/buildSrc/src/main/kotlin/uk/gov/justice/digital/hmpps/gradle/CloudPlatformTask.kt
+++ b/buildSrc/src/main/kotlin/uk/gov/justice/digital/hmpps/gradle/CloudPlatformTask.kt
@@ -1,0 +1,119 @@
+package uk.gov.justice.digital.hmpps.gradle
+
+import groovy.json.JsonException
+import groovy.json.JsonSlurper
+import org.gradle.api.DefaultTask
+import org.gradle.api.internal.tasks.userinput.UserInputHandler
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.Optional
+import org.gradle.api.tasks.options.Option
+import org.gradle.api.tasks.options.OptionValues
+import org.gradle.configurationcache.extensions.serviceOf
+import java.io.IOException
+import java.security.SecureRandom
+import kotlin.io.encoding.Base64
+import kotlin.io.encoding.ExperimentalEncodingApi
+
+abstract class CloudPlatformTask : DefaultTask() {
+  init {
+    group = "cloud-platform"
+  }
+
+  @Optional
+  open var environment: Environment? = null
+    @Input
+    get
+    @Option(option = "environment", description = "Environment hosted in Cloud Platform")
+    set
+
+  @get:OptionValues("environment")
+  val environments = Environment.entries
+
+  open var namespacePrefix: String? = null
+    @Input
+    get
+
+  @get:Internal
+  val userInput: UserInputHandler by lazy {
+    project.serviceOf<UserInputHandler>()
+  }
+
+  @get:Internal
+  val namespace: String by lazy {
+    val namespacePrefix: String = namespacePrefix
+      ?: userInput.askQuestion("Enter namespace prefix", null)
+      ?: throw IllegalArgumentException("Set task property `namespacePrefix` or enter a namespace prefix")
+
+    val environment: Environment = environment
+      ?: userInput.selectOption(
+        "Choose environment",
+        environments,
+        null,
+      )
+      ?: throw IllegalArgumentException("Provide `--environment $environments` command line argument or choose option")
+
+    "$namespacePrefix-$environment"
+  }
+
+  protected fun generateRandomName(prefix: String, length: Int = 5): String {
+    val bytes = ByteArray(length)
+    SecureRandom().nextBytes(bytes)
+    val suffix = buildString {
+      for (byte in bytes) {
+        append(String.format("%02x", byte))
+      }
+    }
+    return "$prefix-$suffix"
+  }
+
+  @Internal
+  protected fun getSecret(secret: String): Map<String, String>? {
+    val process = ProcessBuilder(
+      "kubectl", "--namespace", namespace,
+      "get", "secret", secret,
+      "--output", "json",
+    ).start()
+    val output = try {
+      JsonSlurper().parse(process.inputStream) as Map<*, *>
+    } catch (e: JsonException) {
+      logger.warn("Secret `$secret` not found or unreadable")
+      return null
+    }
+    val exitCode = process.waitFor()
+    if (exitCode != 0) {
+      throw IOException("kubectl exited with code $exitCode")
+    }
+    return decodeSecretMap(output["data"] as Map<*, *>)
+  }
+
+  @Internal
+  protected fun getAllSecrets(): Map<String, Map<String, String>> {
+    val process = ProcessBuilder(
+      "kubectl", "--namespace", namespace,
+      "get", "secret",
+      "--output", "json",
+    ).start()
+    val output = JsonSlurper().parse(process.inputStream) as Map<*, *>
+    val exitCode = process.waitFor()
+    if (exitCode != 0) {
+      throw IOException("kubectl exited with code $exitCode")
+    }
+    val items = output["items"] as List<*>
+    return items.associate { it ->
+      val item = it as Map<*, *>
+      val metadata = item["metadata"] as Map<*, *>
+      val data = decodeSecretMap(item["data"] as Map<*, *>)
+      metadata["name"] as String to data
+    }
+  }
+
+  @OptIn(ExperimentalEncodingApi::class)
+  private fun decodeSecretMap(data: Map<*, *>): Map<String, String> {
+    val decodedData = data.mapValues { (_, value) ->
+      String(Base64.decode(value as String))
+    }
+    @Suppress("UNCHECKED_CAST")
+    return decodedData as Map<String, String>
+  }
+}

--- a/buildSrc/src/main/kotlin/uk/gov/justice/digital/hmpps/gradle/Environment.kt
+++ b/buildSrc/src/main/kotlin/uk/gov/justice/digital/hmpps/gradle/Environment.kt
@@ -1,0 +1,6 @@
+package uk.gov.justice.digital.hmpps.gradle
+
+@Suppress("EnumEntryName")
+enum class Environment {
+  dev, preprod, prod;
+}

--- a/buildSrc/src/main/kotlin/uk/gov/justice/digital/hmpps/gradle/PortForwardRDSTask.kt
+++ b/buildSrc/src/main/kotlin/uk/gov/justice/digital/hmpps/gradle/PortForwardRDSTask.kt
@@ -1,0 +1,49 @@
+package uk.gov.justice.digital.hmpps.gradle
+
+import org.gradle.api.tasks.Input
+
+/**
+ * Connect a local port to RDS in Cloud Platform
+ *
+ * ```build.gradle.kts
+ * tasks.register<PortForwardRDSTask>("portForwardRDS") {
+ *     namespacePrefix = "hmpps-????"
+ * }
+ * ```
+ *
+ * ```shell
+ * ./gradlew help --task portForwardRDS
+ * ./gradlew portForwardRDS --environment dev --port 8432
+ * ```
+ */
+open class PortForwardRDSTask : PortForwardTask() {
+  init {
+    description = "Connect a local port to RDS in Cloud Platform"
+  }
+
+  override var secretName: String? = "dps-rds-instance-output"
+    @Input
+    get
+
+  override var remotePort: Int? = 5432
+    @Input
+    get
+
+  override fun getRemoteHostFromSecret(secret: Map<String, String>): String {
+    return secret["rds_instance_address"]!!
+  }
+
+  override fun showUsageInstructions(secret: Map<String, String>) {
+    val database = secret["database_name"]!!
+    val username = secret["database_username"]!!
+    println(
+      """
+      Usage example:
+      `psql -h 127.0.0.1 -p $localPort -U $username $database`
+      Get RDS password with:
+      `kubectl --namespace $namespace get secret $secretName -o jsonpath={.data.database_password} | base64 -D`
+      Close port-forwarding connection with Ctrl-C. 
+      """.trimIndent(),
+    )
+  }
+}

--- a/buildSrc/src/main/kotlin/uk/gov/justice/digital/hmpps/gradle/PortForwardRedisTask.kt
+++ b/buildSrc/src/main/kotlin/uk/gov/justice/digital/hmpps/gradle/PortForwardRedisTask.kt
@@ -1,0 +1,48 @@
+package uk.gov.justice.digital.hmpps.gradle
+
+import org.gradle.api.tasks.Input
+
+/**
+ * Connect a local port to ElastiCache Redis in Cloud Platform
+ *
+ * ```build.gradle.kts
+ * tasks.register<PortForwardRedisTask>("portForwardRedis") {
+ *     namespacePrefix = "hmpps-????"
+ * }
+ * ```
+ *
+ * ```shell
+ * ./gradlew help --task portForwardRedis
+ * ./gradlew portForwardRedis --environment dev
+ * ```
+ */
+open class PortForwardRedisTask : PortForwardTask() {
+  init {
+    description = "Connect a local port to ElastiCache Redis in Cloud Platform"
+  }
+
+  override var secretName: String? = "elasticache-redis"
+    @Input
+    get
+
+  override var remotePort: Int? = 6379
+    @Input
+    get
+
+  override fun getRemoteHostFromSecret(secret: Map<String, String>): String {
+    return secret["primary_endpoint_address"]!!
+  }
+
+  override fun showUsageInstructions(secret: Map<String, String>) {
+    println(
+      """
+      Usage example:
+      `redis-cli -h 127.0.0.1 -p $localPort --tls --insecure --askpass`
+      Get Redis auth token with:
+      `kubectl --namespace $namespace get secret $secretName -o jsonpath={.data.auth_token} | base64 -D`
+      NB: Redis client must support TLS but must not check certificates as the domain will be incorrect.
+      Close port-forwarding connection with Ctrl-C. 
+      """.trimIndent(),
+    )
+  }
+}

--- a/buildSrc/src/main/kotlin/uk/gov/justice/digital/hmpps/gradle/PortForwardTask.kt
+++ b/buildSrc/src/main/kotlin/uk/gov/justice/digital/hmpps/gradle/PortForwardTask.kt
@@ -1,0 +1,135 @@
+package uk.gov.justice.digital.hmpps.gradle
+
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Optional
+import org.gradle.api.tasks.TaskAction
+import org.gradle.api.tasks.options.Option
+import org.gradle.work.DisableCachingByDefault
+
+/**
+ * Abstract gradle task to connect a local port to an AWS resource in Cloud Platform,
+ * such as an RDS database or ElastiCache Redis
+ */
+@DisableCachingByDefault
+abstract class PortForwardTask : CloudPlatformTask() {
+  init {
+    description = "Connect a local port to an AWS resource in Cloud Platform"
+  }
+
+  open var secretName: String? = null
+    @Input
+    get
+
+  open var remotePort: Int? = null
+    @Input
+    get
+
+  @Optional
+  open var localPort: Int? = null
+    @Input
+    get
+
+  @Option(option = "port", description = "Local port to open (defaults to remote port)")
+  fun setLocalPortString(port: String): PortForwardTask {
+    this.localPort = port.toIntOrNull() ?: throw IllegalArgumentException("Invalid port")
+    return this
+  }
+
+  @Optional
+  open var podName: String? = null
+    @Input
+    get
+    @Option(option = "pod-name", description = "Name of pod used for port-forwarding (generated if not supplied)")
+    set
+
+  @TaskAction
+  fun taskAction() {
+    val secretName = secretName ?: throw IllegalArgumentException("secretName must be provided")
+    val remotePort = remotePort ?: throw IllegalArgumentException("remotePort must be provided")
+    if (localPort == null) {
+      localPort = remotePort
+    }
+    val localPort = localPort ?: throw IllegalStateException("unreachable")
+    if (podName == null) {
+      podName = generateRandomName("port-forward")
+    }
+    val podName = podName ?: throw IllegalStateException("unreachable")
+
+    logger.info("Will connect to AWS resource in $environment to local port $localPort")
+
+    val secret = getSecret(secretName)
+      ?: throw IllegalArgumentException("Secret `$secretName` not found")
+    val remoteHost = getRemoteHostFromSecret(secret)
+
+    launchPortForwardingPod(podName, remoteHost, remotePort)
+    awaitPodReadiness(podName)
+    val portForwardProcess = portForward(podName)
+    showUsageInstructions(secret)
+    try {
+      portForwardProcess.waitFor()
+    } catch (e: InterruptedException) {
+      // NB: gradle disconnects loggers and output so nothing will be seen
+      logger.info("Disconnecting port-forwarding because of interruption")
+    } finally {
+      portForwardProcess.destroy()
+      deletePod(podName)
+    }
+  }
+
+  open fun showUsageInstructions(secret: Map<String, String>) {
+    println("Close port-forwarding connection with Ctrl-C.")
+  }
+
+  abstract fun getRemoteHostFromSecret(secret: Map<String, String>): String
+
+  private fun launchPortForwardingPod(podName: String, remoteHost: String, remotePort: Int) {
+    logger.info("Launching port-forwarding pod $podName in $namespace")
+    ProcessBuilder(
+      "kubectl", "--namespace", namespace,
+      "run", podName,
+      "--image=ministryofjustice/port-forward", "--image-pull-policy=Always", "--restart=Never",
+      "--env", "REMOTE_HOST=$remoteHost", "--env", "REMOTE_PORT=$remotePort", "--env", "LOCAL_PORT=$remotePort",
+      "--port=$remotePort",
+    )
+      .start()
+      .waitFor()
+    logger.info("Launched port-forwarding pod $podName in $namespace")
+  }
+
+  private fun awaitPodReadiness(podName: String) {
+    logger.info("Waiting for pod $podName readiness in $namespace")
+    ProcessBuilder(
+      "kubectl", "--namespace", namespace,
+      "wait", "pod/$podName",
+      "--for", "condition=Ready", "--timeout=60s",
+    )
+      .start()
+      .waitFor()
+    logger.info("Port-forwarding pod $podName is ready in $namespace")
+  }
+
+  private fun portForward(podName: String): Process {
+    logger.info("Starting port-forwarding from local port $localPort to $podName port $remotePort in $namespace")
+    return ProcessBuilder(
+      "kubectl", "--namespace", namespace,
+      "port-forward", "pod/$podName",
+      "$localPort:$remotePort",
+    )
+      .start()
+      .also {
+        logger.info("Port-forwarding on process ID ${it.pid()}")
+      }
+  }
+
+  private fun deletePod(podName: String) {
+    logger.info("Deleting port-forwarding pod $podName in $namespace")
+    ProcessBuilder(
+      "kubectl", "--namespace", namespace,
+      "delete", "pod", podName,
+      "--wait=false",
+    )
+      .start()
+      .waitFor()
+    logger.info("Deleted port-forwarding pod $podName in $namespace")
+  }
+}

--- a/buildSrc/src/main/kotlin/uk/gov/justice/digital/hmpps/gradle/RevealSecretsTask.kt
+++ b/buildSrc/src/main/kotlin/uk/gov/justice/digital/hmpps/gradle/RevealSecretsTask.kt
@@ -1,0 +1,79 @@
+package uk.gov.justice.digital.hmpps.gradle
+
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Optional
+import org.gradle.api.tasks.TaskAction
+import org.gradle.api.tasks.options.Option
+import org.gradle.work.DisableCachingByDefault
+
+/**
+ * List kubernetes secrets or reveal their values
+ *
+ * ```build.gradle.kts
+ * tasks.register<RevealSecretsTask>("revealSecrets") {
+ *     namespacePrefix = "hmpps-????"
+ * }
+ * ```
+ *
+ * ```shell
+ * ./gradlew help --task revealSecrets
+ * ./gradlew revealSecrets
+ * ./gradlew revealSecrets --environment dev --secret dps-rds-instance-output
+ * ```
+ */
+@DisableCachingByDefault
+open class RevealSecretsTask : CloudPlatformTask() {
+  init {
+    description = "Connect a local port to an AWS resource in Cloud Platform"
+  }
+
+  @Optional
+  open var secretName: String? = null
+    @Input
+    get
+    @Option(option = "secret", description = "Secret to reveal (lists all secrets if not provided)")
+    set
+
+  @TaskAction
+  fun taskAction() {
+    secretName?.let {
+      revealSecret(it)
+      return
+    }
+    listSecrets()
+  }
+
+  private fun revealSecret(secretName: String) {
+    getSecret(secretName)?.let {
+      if (it.isEmpty()) {
+        println("Secret `$secretName` contains nothing")
+        return
+      }
+
+      println("===============================================================================")
+      it.forEach { (key, value) ->
+        println("$key=$value")
+      }
+      println("===============================================================================")
+      return
+    }
+
+    println("Secret `$secretName` not found")
+  }
+
+  private fun listSecrets() {
+    val secrets = getAllSecrets()
+    if (secrets.isEmpty()) {
+      println("No secrets found")
+      return
+    }
+
+    val maxNameLength = secrets.keys.maxOfOrNull { it.length }!!
+    println("===============================================================================")
+    secrets.forEach { (name, secret) ->
+      val justifiedName = name.padEnd(maxNameLength)
+      println("$justifiedName  ${secret.size}")
+    }
+    println("===============================================================================")
+  }
+}


### PR DESCRIPTION
There are 3 common tasks that could be more usefully automated:

• connecting a local port to an AWS RDS instance in Cloud Platform
• connecting a local port to an AWS ElastiCache Redis instance in Cloud Platform
• listing and revealing kubernetes secrets in Cloud Platform

…each of which could be performed with a sequence of shell commands, but they would be more complex, project-specific and the first two require clean-up steps.

For example, [connecting to RDS](https://user-guide.cloud-platform.service.justice.gov.uk/documentation/other-topics/rds-external-access.html):

```shell
kubectl \
  --namespace hmpps-non-associations-dev \
  get secret dps-rds-instance-output \
  -o jsonpath={.data.rds_instance_address} \
  | base64 -D \
  | read rds_instance_address
kubectl \
  --namespace hmpps-non-associations-dev \
  run port-forward-pod \
  --image=ministryofjustice/port-forward \
  --port=5432 \
  --env="REMOTE_HOST=$rds_instance_address" \
  --env="LOCAL_PORT=5432" \
  --env="REMOTE_PORT=5432"
kubectl \
  --namespace hmpps-non-associations-dev \
  port-forward \
  port-forward-pod 5432:5432
# use connection
kubectl \
  --namespace hmpps-non-associations-dev \
  delete pod port-forward-pod
```

vs.

```shell
./gradlew portForwardRds
# use connection
^C
```

For the non-associations project, the first two tasks can already be performed by scripts in the [UI app](https://github.com/ministryofjustice/hmpps-non-associations/tree/a9567fdeb5fe0c0f8dcf3424ca4097b4158762c9/bin), but interacting with the hosting platform feels like a better fit for this api repository.

---

Ideally, this could be turned into a gradle plugin to be shared across HMPPS Kotlin projects or added to [hmpps-template-kotlin](https://github.com/ministryofjustice/hmpps-template-kotlin) itself.