### PR TITLE
NON-263: Enable preprod database sync from prod DB

### DIFF
--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -11,6 +11,20 @@ generic-service:
     API_BASE_URL_OFFENDER_SEARCH: https://prisoner-offender-search.prison.service.justice.gov.uk
     FEATURE_LEGACY_ENDPOINT_NOMIS_SOURCE_OF_TRUTH: true
 
+  postgresDatabaseRestore:
+    enabled: true
+    namespace_secrets:
+      dps-rds-instance-output:
+        DB_NAME: "database_name"
+        DB_USER: "database_username"
+        DB_PASS: "database_password"
+        DB_HOST: "rds_instance_address"
+      dps-rds-instance-output-preprod:
+        DB_NAME_PREPROD: "database_name"
+        DB_USER_PREPROD: "database_username"
+        DB_PASS_PREPROD: "database_password"
+        DB_HOST_PREPROD: "rds_instance_address"
+
 # CloudPlatform AlertManager receiver to route prometheus alerts to slack
 # See https://user-guide.cloud-platform.service.justice.gov.uk/documentation/monitoring-an-app/how-to-create-alarms.html#creating-your-own-custom-alerts
 generic-prometheus-alerts:


### PR DESCRIPTION
This is enabling the preprod syncing of the generic service helm chart, [see docs](https://github.com/ministryofjustice/hmpps-helm-charts/tree/main/charts/generic-service#prison-postgres-database-restore-cronjob
).

This is using the proprod DB secrets (in the production namespace) created in [this PR Cloud Platform environments PR](https://github.com/ministryofjustice/cloud-platform-environments/pull/16797).

Similar to what already done for Incentives ([see Incentives PR](https://github.com/ministryofjustice/hmpps-incentives-api/pull/345/files#diff-bb4e80ba0a6c43663498b44c19e42c074dcceac3d9564b49801202073b5c87ffR14)).

- [x] Wait for [CP environment PR](https://github.com/ministryofjustice/cloud-platform-environments/pull/16797) to be merged/applied
- [x] Wait for Syscon preprod migration/syncing checks to be done before we merge this (as it would likely trigger overwrite preprod DB with prod data)