### PR TITLE
NON-262: Legacy endpoint using DB in production

### DIFF
--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -9,7 +9,7 @@ generic-service:
     API_BASE_URL_OAUTH: https://sign-in.hmpps.service.justice.gov.uk/auth
     API_BASE_URL_PRISON: https://api.prison.service.justice.gov.uk
     API_BASE_URL_OFFENDER_SEARCH: https://prisoner-offender-search.prison.service.justice.gov.uk
-    FEATURE_LEGACY_ENDPOINT_NOMIS_SOURCE_OF_TRUTH: true
+    FEATURE_LEGACY_ENDPOINT_NOMIS_SOURCE_OF_TRUTH: false
 
   postgresDatabaseRestore:
     enabled: true


### PR DESCRIPTION
Switched feature flag in production so that `/legacy` endpoint is now using DB instead of proxying to Prison API (which uses NOMIS data)

This is used in [this `when` statement](https://github.com/ministryofjustice/hmpps-non-associations-api/blob/671d2a9df9a2b97234161474752dec2dbd83da42/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/service/NonAssociationsService.kt#L244-L253):

```Kotlin
return when (featureFlagsConfig.legacyEndpointNomisSourceOfTruth) {
  true -> prisonApiService.getNonAssociationDetails(prisonerNumber, currentPrisonOnly, excludeInactive)
  false -> {
    val inclusion = if (excludeInactive) NonAssociationListInclusion.OPEN_ONLY else NonAssociationListInclusion.ALL
    return getPrisonerNonAssociations(
      prisonerNumber,
      NonAssociationListOptions(inclusion = inclusion, includeOtherPrisons = !currentPrisonOnly),
    ).toLegacy()
  }
}
```

**NOTE**: Wait for migration/syncing, etc before actually merging/deploying - anything else to consider before merging this?