### PR TITLE
NON-287: Disallow adding a non-associations to prisoners with null locations

### DIFF
--- a/clients/node/README.md
+++ b/clients/node/README.md
@@ -110,6 +110,7 @@ General notes regarding permissions and roles:
 - Users also having the `GLOBAL_SEARCH` role can also _add_, _update_ and _close_ non-associations for prisoners in transfer and where one prisoner is not in a prison that’s not in their caseloads
 - Users also having the `INACTIVE_BOOKINGS` role can also _add_, _update_ and _close_ non-associations for prisoners outside any establishment / released
 - Users must _close_ rather than _delete_ non-associations
+- No users should be able to _add_, _update_ or _close_ non-associations for prisoners without a booking / with a null location
 
 Release a new version
 ---------------------

--- a/clients/node/src/errorTypes.ts
+++ b/clients/node/src/errorTypes.ts
@@ -2,7 +2,7 @@
  * Structure representing an error response from the api, wrapped in SanitisedError.
  *
  * Defined in uk.gov.justice.digital.hmpps.hmppsnonassociationsapi.config.ErrorResponse class
- * https://github.com/ministryofjustice/hmpps-non-associations-api/blob/f6002aa1da50b8c4ccd3613e970327d5c67c44ae/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/config/HmppsNonAssociationsApiExceptionHandler.kt#L240-L261
+ * see https://github.com/ministryofjustice/hmpps-non-associations-api
  */
 export interface ErrorResponse {
   status: number
@@ -34,11 +34,12 @@ export function isErrorResponse(obj: unknown): obj is ErrorResponse {
  * Unique codes to discriminate errors returned from the api.
  *
  * Defined in uk.gov.justice.digital.hmpps.hmppsnonassociationsapi.config.ErrorCode enumeration
- * https://github.com/ministryofjustice/hmpps-non-associations-api/blob/f6002aa1da50b8c4ccd3613e970327d5c67c44ae/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/config/HmppsNonAssociationsApiExceptionHandler.kt#L227-L238
+ * see https://github.com/ministryofjustice/hmpps-non-associations-api
  */
 export enum ErrorCode {
   NonAssociationAlreadyClosed = 100,
   OpenNonAssociationAlreadyExist = 101,
   ValidationFailure = 102,
+  NullPrisonerLocations = 103,
   UserInContextMissing = 401,
 }

--- a/clients/node/src/responseTypes.ts
+++ b/clients/node/src/responseTypes.ts
@@ -26,8 +26,8 @@ interface BaseNonAssociationsListItem extends ObjectWithDates {
     roleDescription: Role[keyof Role]
     firstName: string
     lastName: string
-    prisonId: string
-    prisonName: string
+    prisonId?: string
+    prisonName?: string
     cellLocation?: string
   }
 }
@@ -58,8 +58,8 @@ export interface NonAssociationsList<
   prisonerNumber: string
   firstName: string
   lastName: string
-  prisonId: string
-  prisonName: string
+  prisonId?: string
+  prisonName?: string
   cellLocation?: string
   openCount: number
   closedCount: number

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/config/HmppsNonAssociationsApiExceptionHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/config/HmppsNonAssociationsApiExceptionHandler.kt
@@ -219,6 +219,21 @@ class HmppsNonAssociationsApiExceptionHandler {
       )
   }
 
+  @ExceptionHandler(NullPrisonerLocationsException::class)
+  fun handleNullPrisonerLocationsException(e: NullPrisonerLocationsException): ResponseEntity<ErrorResponse?>? {
+    log.debug("Non-association cannot be created when prisoner locations are null: {}", e.message)
+    return ResponseEntity
+      .status(CONFLICT)
+      .body(
+        ErrorResponse(
+          status = CONFLICT,
+          errorCode = ErrorCode.NullPrisonerLocations,
+          userMessage = "Non-association cannot be created when prisoner locations are null: ${e.message}",
+          developerMessage = e.message,
+        ),
+      )
+  }
+
   companion object {
     private val log = LoggerFactory.getLogger(this::class.java)
   }
@@ -235,6 +250,7 @@ enum class ErrorCode(val errorCode: Int) {
   UserInContextMissing(401),
   OpenNonAssociationAlreadyExist(101),
   ValidationFailure(102),
+  NullPrisonerLocations(103),
 }
 
 @Schema(description = "Error response")
@@ -267,3 +283,5 @@ class UserInContextMissingException : Exception("There is no user in context for
 class OpenNonAssociationAlreadyExistsException(prisoners: List<String>) : Exception("Prisoners $prisoners already have open non-associations")
 
 class NonAssociationNotFoundException(id: Long) : Exception("There is no non-association found for ID = $id")
+
+class NullPrisonerLocationsException(prisoners: List<String>) : Exception("Prisoners $prisoners have null locations")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/dto/LegacyPrisonerNonAssociations.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/dto/LegacyPrisonerNonAssociations.kt
@@ -14,10 +14,10 @@ data class LegacyPrisonerNonAssociations(
   val firstName: String,
   @Schema(description = "Last name", required = true, example = "Hall")
   val lastName: String,
-  @Schema(description = "Prison ID where prisoner resides or OUT for released", required = true, example = "MDI")
-  val agencyId: String,
-  @Schema(description = "Description of the agency (e.g. prison) the offender is assigned to", required = true, example = "Moorland (HMP & YOI)")
-  val agencyDescription: String,
+  @Schema(description = "Prison ID where prisoner resides or OUT for released", required = false, example = "MDI")
+  val agencyId: String?,
+  @Schema(description = "Description of the agency (e.g. prison) the offender is assigned to", required = false, example = "Moorland (HMP & YOI)")
+  val agencyDescription: String?,
   @Schema(description = "Description of living unit (e.g. cell) the offender is assigned to.", required = false, example = "MDI-1-1-3")
   val assignedLivingUnitDescription: String?,
   @Schema(description = "Non-associations with other prisoners", required = true)
@@ -64,10 +64,10 @@ data class LegacyOtherPrisonerDetails(
   val reasonCode: LegacyReason,
   @Schema(description = "Reason for the non-association", required = true, example = "Perpetrator")
   val reasonDescription: String,
-  @Schema(description = "Prison ID where prisoner resides or OUT for released", required = true, example = "MDI")
-  val agencyId: String,
-  @Schema(description = "Description of the agency (e.g. prison) the offender is assigned to", required = true, example = "Moorland (HMP & YOI)")
-  val agencyDescription: String,
+  @Schema(description = "Prison ID where prisoner resides or OUT for released", required = false, example = "MDI")
+  val agencyId: String?,
+  @Schema(description = "Description of the agency (e.g. prison) the offender is assigned to", required = false, example = "Moorland (HMP & YOI)")
+  val agencyDescription: String?,
   @Schema(description = "Description of living unit (e.g. cell) the offender is assigned to.", required = false, example = "MDI-2-3-4")
   val assignedLivingUnitDescription: String?,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/dto/PrisonerNonAssociations.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/dto/PrisonerNonAssociations.kt
@@ -16,10 +16,10 @@ data class PrisonerNonAssociations(
   val firstName: String,
   @Schema(description = "Last name", required = true, example = "Hall")
   val lastName: String,
-  @Schema(description = "ID of the prison the prisoner is assigned to", required = true, example = "MDI")
-  val prisonId: String,
-  @Schema(description = "Name of the prison the prisoner is assigned to", required = true, example = "Moorland (HMP & YOI)")
-  val prisonName: String,
+  @Schema(description = "ID of the prison the prisoner is assigned to", required = false, example = "MDI")
+  val prisonId: String?,
+  @Schema(description = "Name of the prison the prisoner is assigned to", required = false, example = "Moorland (HMP & YOI)")
+  val prisonName: String?,
   @Schema(description = "Cell the prisoner is assigned to", required = false, example = "A-1-002")
   val cellLocation: String?,
   @Schema(description = "Number of open non-associations (follows includeOtherPrisons filter)", required = true, example = "1", minimum = "0", type = "integer", format = "int32")
@@ -93,10 +93,10 @@ data class OtherPrisonerDetails(
   val firstName: String,
   @Schema(description = "Last name", required = true, example = "Bloggs")
   val lastName: String,
-  @Schema(description = "ID of the prison the prisoner is assigned to", required = true, example = "MDI")
-  val prisonId: String,
-  @Schema(description = "Name of the prison the prisoner is assigned to", required = true, example = "Moorland (HMP & YOI)")
-  val prisonName: String,
+  @Schema(description = "ID of the prison the prisoner is assigned to", required = false, example = "MDI")
+  val prisonId: String?,
+  @Schema(description = "Name of the prison the prisoner is assigned to", required = false, example = "Moorland (HMP & YOI)")
+  val prisonName: String?,
   @Schema(description = "Cell the prisoner is assigned to", required = false, example = "B-2-007")
   val cellLocation: String?,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/dto/offendersearch/OffenderSearchPrisoner.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/dto/offendersearch/OffenderSearchPrisoner.kt
@@ -5,7 +5,7 @@ data class OffenderSearchPrisoner(
   val firstName: String,
   val lastName: String,
 
-  val prisonId: String,
-  val prisonName: String,
+  val prisonId: String?,
+  val prisonName: String?,
   val cellLocation: String?,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/resource/NonAssociationsResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/resource/NonAssociationsResource.kt
@@ -187,7 +187,12 @@ class NonAssociationsResource(
       ),
       ApiResponse(
         responseCode = "404",
-        description = "Any of the prisoners could not be found.",
+        description = "Some of the prisoners were not be found.",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+      ApiResponse(
+        responseCode = "409",
+        description = "Open non-association already exists or some prisoner’s location is null.",
         content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
       ),
     ],

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/resource/NonAssociationsResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/resource/NonAssociationsResourceTest.kt
@@ -324,6 +324,41 @@ class NonAssociationsResourceTest : SqsIntegrationTestBase() {
     }
 
     @Test
+    fun `cannot create NA if some prisoner has a null location`() {
+      val firstPrisoner = offenderSearchPrisoners["A1234BC"]!!
+      val secondPrisoner = offenderSearchPrisoners["D1234DD"]!!
+
+      offenderSearchMockServer.stubSearchByPrisonerNumbers(
+        listOf("A1234BC", "D1234DD"),
+        listOf(firstPrisoner, secondPrisoner),
+      )
+
+      val request = createNonAssociationRequest(
+        firstPrisonerNumber = firstPrisoner.prisonerNumber,
+        firstPrisonerRole = Role.VICTIM,
+        secondPrisonerNumber = secondPrisoner.prisonerNumber,
+        secondPrisonerRole = Role.PERPETRATOR,
+        reason = Reason.VIOLENCE,
+        restrictionType = RestrictionType.CELL,
+        comment = "They keep fighting",
+      )
+
+      webTestClient.post()
+        .uri(url)
+        .headers(
+          setAuthorisation(
+            user = expectedUsername,
+            roles = listOf("ROLE_WRITE_NON_ASSOCIATIONS"),
+            scopes = listOf("write", "read"),
+          ),
+        )
+        .header("Content-Type", "application/json")
+        .bodyValue(jsonString(request))
+        .exchange()
+        .expectStatus().isEqualTo(409)
+    }
+
+    @Test
     fun `can create NA for already closed NA between same prisoners`() {
       val firstPrisoner = offenderSearchPrisoners["A1234BC"]!!
       val secondPrisoner = offenderSearchPrisoners["D5678EF"]!!

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/resource/NonAssociationsResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/resource/NonAssociationsResourceTest.kt
@@ -2512,15 +2512,15 @@ class NonAssociationsResourceTest : SqsIntegrationTestBase() {
 
     @Test
     fun `when non-associations are requested between more than 2 prisoners`() {
-      // language=mermaid
-      """
+      /*
+      %% language=mermaid
       classDiagram
         A0000AA -- A1111AA
         A0000AA -- A2222AA
         A2222AA -- A3333AA
         A1111AA -- A4444AA
         A4444AA -- A2222AA : closed
-      """
+      */
       createNonAssociation("A0000AA", "A1111AA") // never returned
       createNonAssociation("A0000AA", "A2222AA") // returned
       createNonAssociation("A2222AA", "A3333AA") // never returned
@@ -2865,15 +2865,15 @@ class NonAssociationsResourceTest : SqsIntegrationTestBase() {
 
     @Test
     fun `when non-associations are requested involving more than 2 prisoners`() {
-      // language=mermaid
-      """
+      /*
+      %% language=mermaid
       classDiagram
         A0000AA -- A1111AA
         A0000AA -- A2222AA
         A2222AA -- A3333AA
         A1111AA -- A4444AA
         A4444AA -- A2222AA : closed
-      """
+      */
       createNonAssociation("A0000AA", "A1111AA") // never returned
       createNonAssociation("A0000AA", "A2222AA") // returned
       createNonAssociation("A2222AA", "A3333AA") // returned

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/service/NonAssociationsServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/service/NonAssociationsServiceTest.kt
@@ -167,9 +167,9 @@ class NonAssociationsServiceTest {
           NonAssociationsSort.LAST_NAME -> { n -> n.otherPrisonerDetails.lastName }
           NonAssociationsSort.FIRST_NAME -> { n -> n.otherPrisonerDetails.firstName }
           NonAssociationsSort.PRISONER_NUMBER -> { n -> n.otherPrisonerDetails.prisonerNumber }
-          NonAssociationsSort.PRISON_ID -> { n -> n.otherPrisonerDetails.prisonId }
-          NonAssociationsSort.PRISON_NAME -> { n -> n.otherPrisonerDetails.prisonName }
-          NonAssociationsSort.CELL_LOCATION -> { n -> n.otherPrisonerDetails.cellLocation!! }
+          NonAssociationsSort.PRISON_ID -> { n -> n.otherPrisonerDetails.prisonId ?: "" }
+          NonAssociationsSort.PRISON_NAME -> { n -> n.otherPrisonerDetails.prisonName ?: "" }
+          NonAssociationsSort.CELL_LOCATION -> { n -> n.otherPrisonerDetails.cellLocation ?: "" }
         }
         Sort.Direction.entries.forEach { sortDirection ->
           val listOptions = NonAssociationListOptions(sortBy = sortBy, sortDirection = sortDirection)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/util/TestData.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/util/TestData.kt
@@ -104,4 +104,31 @@ val offenderSearchPrisoners = mapOf(
     prisonName = "Forest Bank",
     cellLocation = "FBI-C-2",
   ),
+  // In transfer
+  "C1234CC" to OffenderSearchPrisoner(
+    prisonerNumber = "C1234CC",
+    firstName = "MAX",
+    lastName = "CLARKE",
+    prisonId = "TRN",
+    prisonName = "Transfer",
+    cellLocation = null,
+  ),
+  // Outside any establishment
+  "B1234BB" to OffenderSearchPrisoner(
+    prisonerNumber = "B1234BB",
+    firstName = "JOE",
+    lastName = "PETERS",
+    prisonId = "OUT",
+    prisonName = "Outside - released from Moorland (HMP)",
+    cellLocation = null,
+  ),
+  // Null location, allegedly indicates no booking
+  "D1234DD" to OffenderSearchPrisoner(
+    prisonerNumber = "D1234DD",
+    firstName = "NATHAN",
+    lastName = "LOST",
+    prisonId = null,
+    prisonName = null,
+    cellLocation = null,
+  ),
 )


### PR DESCRIPTION
The api now responds with 409 CONFLICT when trying to create a non-association with a prisoner with a null location.

Also, allow for offender search results that have no prison name or ID. Because those fields _can_ be null, we are forced to propagate the nullability into _this_ api.

**It does mean that our api contract changes!**

Related: [ui#184](https://github.com/ministryofjustice/hmpps-non-associations/pull/184) & [ui#185](https://github.com/ministryofjustice/hmpps-non-associations/pull/185)