### PR TITLE
NON-299: Record user creating a non-association using this api

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/dto/NonAssociation.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/dto/NonAssociation.kt
@@ -85,7 +85,7 @@ data class CreateNonAssociationRequest(
   @field:Size(min = 1, message = "A comment is required")
   val comment: String,
 ) {
-  fun toNewEntity(updatedBy: String, clock: Clock): NonAssociationJPA {
+  fun toNewEntity(createdBy: String, clock: Clock): NonAssociationJPA {
     return NonAssociationJPA(
       id = null,
       firstPrisonerNumber = firstPrisonerNumber,
@@ -95,7 +95,8 @@ data class CreateNonAssociationRequest(
       reason = reason,
       restrictionType = restrictionType,
       comment = comment,
-      updatedBy = updatedBy,
+      authorisedBy = createdBy,
+      updatedBy = createdBy,
       whenCreated = LocalDateTime.now(clock),
       whenUpdated = LocalDateTime.now(clock),
     )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/dto/PrisonerNonAssociations.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/dto/PrisonerNonAssociations.kt
@@ -53,7 +53,7 @@ data class PrisonerNonAssociation(
 
   @Schema(description = "Explanation of why prisoners are non-associated", required = true, example = "John and Luke always end up fighting")
   val comment: String,
-  @Schema(description = "User ID of the person who created the non-association. NOTE: For records migrated from NOMIS/Prison API this is free text and may not be a valid User ID. Additionally, migrated records might use an internal system username", required = true, example = "OFF3_GEN")
+  @Schema(description = "User ID of the person who created the non-association. NOTE: For records migrated from NOMIS/Prison API this is free text and may not be a valid User ID. Additionally, migrated records might use an internal system username. It can be an empty string", required = true, example = "OFF3_GEN")
   val authorisedBy: String,
   @Schema(description = "When the non-association was created", required = true, example = "2021-12-31T12:34:56.789012")
   val whenCreated: LocalDateTime,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/jpa/NonAssociation.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/jpa/NonAssociation.kt
@@ -37,7 +37,9 @@ class NonAssociation(
   var restrictionType: RestrictionType,
   var comment: String,
 
-  var authorisedBy: String? = null, // This is stored for legacy reasons - the data is not returned in the API except on the legacy endpoints
+  // The user who created or authorised a non-association is not always available,
+  // it was a free text field in NOMIS and initially not set when non-associations were created by this api.
+  var authorisedBy: String? = null,
 
   // Non-associations can be closed (with details of who/why/when)
   var isClosed: Boolean = false,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/service/NonAssociationsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/service/NonAssociationsService.kt
@@ -78,7 +78,7 @@ class NonAssociationsService(
     }
 
     val nonAssociationJpa = createNonAssociationRequest.toNewEntity(
-      updatedBy = authenticationFacade.currentUsername
+      createdBy = authenticationFacade.currentUsername
         ?: throw UserInContextMissingException(),
       clock = clock,
     )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/resource/NonAssociationsResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/resource/NonAssociationsResourceTest.kt
@@ -282,6 +282,26 @@ class NonAssociationsResourceTest : SqsIntegrationTestBase() {
           assertThat(nonAssociation.id).isGreaterThan(0)
           assertThat(nonAssociation.whenCreated).isNotNull()
           assertThat(nonAssociation.whenUpdated).isEqualTo(nonAssociation.whenCreated)
+
+          val nonAssociationJpa = repository.findById(nonAssociation.id).get()
+          with(nonAssociationJpa) {
+            assertThat(firstPrisonerNumber).isEqualTo(firstPrisoner.prisonerNumber)
+            assertThat(firstPrisonerRole).isEqualTo(Role.VICTIM)
+            assertThat(secondPrisonerNumber).isEqualTo(secondPrisoner.prisonerNumber)
+            assertThat(secondPrisonerRole).isEqualTo(Role.PERPETRATOR)
+            assertThat(reason).isEqualTo(Reason.VIOLENCE)
+            assertThat(restrictionType).isEqualTo(RestrictionType.CELL)
+            assertThat(comment).isEqualTo("They keep fighting")
+            assertThat(authorisedBy).isEqualTo(expectedUsername)
+            assertThat(updatedBy).isEqualTo(expectedUsername)
+            assertThat(whenCreated).isEqualTo(nonAssociation.whenCreated)
+            assertThat(whenUpdated).isEqualTo(nonAssociation.whenCreated)
+
+            assertThat(isOpen).isTrue()
+            assertThat(closedBy).isNull()
+            assertThat(closedAt).isNull()
+            assertThat(closedReason).isNull()
+          }
         }
     }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/service/NonAssociationsServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/service/NonAssociationsServiceTest.kt
@@ -49,8 +49,8 @@ class NonAssociationsServiceTest {
   fun createNonAssociation() {
     val createNonAssociationRequest: CreateNonAssociationRequest = createNonAssociationRequest()
 
-    val updatedBy = "TEST_USER_GEN"
-    whenever(authenticationFacade.currentUsername).thenReturn(updatedBy)
+    val createdBy = "TEST_USER_GEN"
+    whenever(authenticationFacade.currentUsername).thenReturn(createdBy)
 
     val expectedId = 42L
     val now = LocalDateTime.now(TestBase.clock)
@@ -63,12 +63,12 @@ class NonAssociationsServiceTest {
       comment = createNonAssociationRequest.comment,
       reason = createNonAssociationRequest.reason,
       restrictionType = createNonAssociationRequest.restrictionType,
-      authorisedBy = updatedBy,
+      authorisedBy = createdBy,
       isClosed = false,
       closedBy = null,
       closedReason = null,
       closedAt = null,
-      updatedBy = updatedBy,
+      updatedBy = createdBy,
       whenCreated = now,
       whenUpdated = now,
     )


### PR DESCRIPTION
This is not yet exposed when retrieving individual non-association records, but was already available when listing non-associations for a given prisoner.

The api contract doesn't change, but our record-keeping is improved.