### PR TITLE
Remove health-kick from allow list since it is now within Cloud Platform

### DIFF
--- a/helm_deploy/hmpps-non-associations-api/values.yaml
+++ b/helm_deploy/hmpps-non-associations-api/values.yaml
@@ -63,7 +63,5 @@ generic-service:
     groups:
       - internal
 
-    health-kick: "35.177.252.195/32"
-
 generic-prometheus-alerts:
   targetApplication: hmpps-non-associations-api


### PR DESCRIPTION
Ref: [hmpps-ip-allowlists#2](https://github.com/ministryofjustice/hmpps-ip-allowlists/pull/2)