### PR TITLE
Migrating project to use groups in allowlist

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  hmpps: ministryofjustice/hmpps@7.5
+  hmpps: ministryofjustice/hmpps@7
 
 parameters:
   alerts-slack-channel:
@@ -41,10 +41,10 @@ jobs:
       - run:
           name: Run check
           command: ./gradlew check
-#          name: Run check & send results to sonarcloud
-#          command: |
-#            export GRADLE_OPTS="--add-opens=java.prefs/java.util.prefs=ALL-UNNAMED --add-opens=java.base/java.lang=ALL-UNNAMED"
-#            ./gradlew check sonar --info
+      #          name: Run check & send results to sonarcloud
+      #          command: |
+      #            export GRADLE_OPTS="--add-opens=java.prefs/java.util.prefs=ALL-UNNAMED --add-opens=java.base/java.lang=ALL-UNNAMED"
+      #            ./gradlew check sonar --info
       - save_cache:
           paths:
             - ~/.gradle
@@ -53,8 +53,8 @@ jobs:
           path: build/test-results
       - store_artifacts:
           path: build/reports/tests
-#      - store_artifacts:
-#          path: build/reports/jacoco/test/html
+  #      - store_artifacts:
+  #          path: build/reports/jacoco/test/html
 
   test-node-client:
     parameters:
@@ -69,14 +69,16 @@ jobs:
           name: Update npm
           command: sudo npm install -g npm@latest
       - restore_cache:
-          key: dependency-cache-node<< parameters.node-version >>-{{ checksum "clients/node/package-lock.json" }}
+          key: dependency-cache-node<< parameters.node-version >>-{{ checksum
+            "clients/node/package-lock.json" }}
       - run:
           name: Install dependencies
           command: |
             cd clients/node
             npm clean-install --no-audit
       - save_cache:
-          key: dependency-cache-node<< parameters.node-version >>-{{ checksum "clients/node/package-lock.json" }}
+          key: dependency-cache-node<< parameters.node-version >>-{{ checksum
+            "clients/node/package-lock.json" }}
           paths:
             - clients/node/node_modules
       - run:
@@ -110,7 +112,7 @@ workflows:
       - test-node-client:
           matrix:
             parameters:
-              node-version: ["18.18", "20.9"]
+              node-version: [ "18.18", "20.9" ]
       - hmpps/helm_lint:
           name: helm_lint
       - hmpps/build_multiplatform_docker:

--- a/helm_deploy/hmpps-non-associations-api/Chart.yaml
+++ b/helm_deploy/hmpps-non-associations-api/Chart.yaml
@@ -5,7 +5,7 @@ name: hmpps-non-associations-api
 version: 0.2.0
 dependencies:
   - name: generic-service
-    version: 2.8.1
+    version: "2.8"
     repository: https://ministryofjustice.github.io/hmpps-helm-charts
   - name: generic-prometheus-alerts
     version: 1.3.3

--- a/helm_deploy/hmpps-non-associations-api/values.yaml
+++ b/helm_deploy/hmpps-non-associations-api/values.yaml
@@ -1,4 +1,3 @@
----
 generic-service:
   nameOverride: hmpps-non-associations-api
   productId: "DPS032"
@@ -9,12 +8,12 @@ generic-service:
 
   image:
     repository: quay.io/hmpps/hmpps-non-associations-api
-    tag: app_version    # override at deployment time
+    tag: app_version # override at deployment time
     port: 8080
 
   ingress:
     enabled: true
-    host: app-hostname.local    # override per environment
+    host: app-hostname.local # override per environment
     tlsSecretName: hmpps-non-associations-api-cert
 
   # Environment variables to load into the deployment
@@ -60,8 +59,8 @@ generic-service:
       HMPPS_SQS_QUEUES_NONASSOCIATIONS_DLQ_NAME: "sqs_queue_name"
 
   allowlist:
-    groups:
-      - internal
+    undefined: internal/32
+    groups: []
 
 generic-prometheus-alerts:
   targetApplication: hmpps-non-associations-api


### PR DESCRIPTION
This PR migrates the project to use groups of IPs in their allowlist.

By referring to groups to IP addresses, we can centralize the definition of groups of ip addresses.
If these lists require changing in the future, we can change the definition once and future deploys across all services will automatically include these new IPs.

1 allowlist(s) have been detected that can be migrated.



## Allowlist: helm_deploy/hmpps-non-associations-api/values.yaml

### New Groups

The effect of applying this PR is as follows:

- The following groups will be applied: ``
- The size of the allowlist defined in this file will change: `1 => 1 (0 removed)`

### Added IPs

The new Group membership will result in the following IPs being added to your allowlist by applying this PR:

  Merging this PR should not result in any additional IP addresses being added to the allowlist.

### Removed IPs

The following IPs have been identified as unnecessary and will be removed by applying this PR:

  **No IPs have been identified for removal**
  
