### PR TITLE
Improve exception handling

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/config/HmppsNonAssociationsApiExceptionHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/config/HmppsNonAssociationsApiExceptionHandler.kt
@@ -11,6 +11,7 @@ import org.springframework.http.HttpStatus.FORBIDDEN
 import org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR
 import org.springframework.http.HttpStatus.NOT_FOUND
 import org.springframework.http.HttpStatus.UNAUTHORIZED
+import org.springframework.http.HttpStatus.UNSUPPORTED_MEDIA_TYPE
 import org.springframework.http.ResponseEntity
 import org.springframework.http.converter.HttpMessageNotReadableException
 import org.springframework.security.access.AccessDeniedException
@@ -25,7 +26,7 @@ import org.springframework.web.server.ResponseStatusException
 @RestControllerAdvice
 class HmppsNonAssociationsApiExceptionHandler {
   @ExceptionHandler(ValidationException::class)
-  fun handleValidationException(e: Exception): ResponseEntity<ErrorResponse> {
+  fun handleValidationException(e: ValidationException): ResponseEntity<ErrorResponse> {
     log.info("Validation exception: {}", e.message)
     return ResponseEntity
       .status(BAD_REQUEST)
@@ -39,13 +40,13 @@ class HmppsNonAssociationsApiExceptionHandler {
   }
 
   @ExceptionHandler(HttpMediaTypeNotSupportedException::class)
-  fun handleInvalidRequestFormatValidationException(e: Exception): ResponseEntity<ErrorResponse> {
+  fun handleInvalidRequestFormatValidationException(e: HttpMediaTypeNotSupportedException): ResponseEntity<ErrorResponse> {
     log.info("Validation exception: Request format not supported: {}", e.message)
     return ResponseEntity
-      .status(BAD_REQUEST)
+      .status(UNSUPPORTED_MEDIA_TYPE)
       .body(
         ErrorResponse(
-          status = BAD_REQUEST,
+          status = UNSUPPORTED_MEDIA_TYPE,
           userMessage = "Validation failure: Request format not supported: ${e.message}",
           developerMessage = e.message,
         ),
@@ -53,7 +54,7 @@ class HmppsNonAssociationsApiExceptionHandler {
   }
 
   @ExceptionHandler(HttpMessageNotReadableException::class)
-  fun handleNoBodyValidationException(e: Exception): ResponseEntity<ErrorResponse> {
+  fun handleNoBodyValidationException(e: HttpMessageNotReadableException): ResponseEntity<ErrorResponse> {
     log.info("Validation exception: Couldn't read request body: {}", e.message)
     return ResponseEntity
       .status(BAD_REQUEST)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/config/HmppsNonAssociationsApiExceptionHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/config/HmppsNonAssociationsApiExceptionHandler.kt
@@ -40,7 +40,7 @@ class HmppsNonAssociationsApiExceptionHandler {
   }
 
   @ExceptionHandler(HttpMediaTypeNotSupportedException::class)
-  fun handleInvalidRequestFormatValidationException(e: HttpMediaTypeNotSupportedException): ResponseEntity<ErrorResponse> {
+  fun handleInvalidRequestFormatException(e: HttpMediaTypeNotSupportedException): ResponseEntity<ErrorResponse> {
     log.info("Validation exception: Request format not supported: {}", e.message)
     return ResponseEntity
       .status(UNSUPPORTED_MEDIA_TYPE)
@@ -206,7 +206,7 @@ class HmppsNonAssociationsApiExceptionHandler {
   }
 
   @ExceptionHandler(MethodArgumentNotValidException::class)
-  fun handleValidationException(e: MethodArgumentNotValidException): ResponseEntity<ErrorResponse>? {
+  fun handleInvalidMethodArgumentException(e: MethodArgumentNotValidException): ResponseEntity<ErrorResponse>? {
     log.debug("MethodArgumentNotValidException exception caught: {}", e.message)
 
     return ResponseEntity

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/resource/LegacyResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/resource/LegacyResource.kt
@@ -15,8 +15,8 @@ import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
-import org.springframework.web.server.ResponseStatusException
 import uk.gov.justice.digital.hmpps.hmppsnonassociationsapi.config.ErrorResponse
+import uk.gov.justice.digital.hmpps.hmppsnonassociationsapi.config.NonAssociationNotFoundException
 import uk.gov.justice.digital.hmpps.hmppsnonassociationsapi.dto.LegacyNonAssociation
 import uk.gov.justice.digital.hmpps.hmppsnonassociationsapi.dto.LegacyPrisonerNonAssociations
 import uk.gov.justice.digital.hmpps.hmppsnonassociationsapi.service.NonAssociationsService
@@ -110,9 +110,7 @@ class LegacyResource(
     @PathVariable
     id: Long,
   ): LegacyNonAssociation {
-    return nonAssociationsService.getLegacyById(id) ?: throw ResponseStatusException(
-      HttpStatus.NOT_FOUND,
-      "Non-association with ID $id not found",
-    )
+    return nonAssociationsService.getLegacyById(id)
+      ?: throw NonAssociationNotFoundException(id)
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/resource/NonAssociationsResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/resource/NonAssociationsResource.kt
@@ -28,6 +28,7 @@ import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
 import org.springframework.web.server.ResponseStatusException
 import uk.gov.justice.digital.hmpps.hmppsnonassociationsapi.config.ErrorResponse
+import uk.gov.justice.digital.hmpps.hmppsnonassociationsapi.config.NonAssociationNotFoundException
 import uk.gov.justice.digital.hmpps.hmppsnonassociationsapi.dto.CloseNonAssociationRequest
 import uk.gov.justice.digital.hmpps.hmppsnonassociationsapi.dto.CreateNonAssociationRequest
 import uk.gov.justice.digital.hmpps.hmppsnonassociationsapi.dto.DeleteNonAssociationRequest
@@ -303,7 +304,7 @@ class NonAssociationsResource(
     id: Long,
   ): NonAssociation {
     return nonAssociationsService.getById(id)
-      ?: throw ResponseStatusException(HttpStatus.NOT_FOUND, "Non-association with ID $id not found")
+      ?: throw NonAssociationNotFoundException(id)
   }
 
   @PostMapping("/non-associations/between")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/resource/NonAssociationsResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/resource/NonAssociationsResource.kt
@@ -6,6 +6,7 @@ import io.swagger.v3.oas.annotations.media.Content
 import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.tags.Tag
+import jakarta.validation.ValidationException
 import jakarta.validation.constraints.Pattern
 import org.springdoc.core.annotations.ParameterObject
 import org.springframework.data.domain.Page
@@ -26,7 +27,6 @@ import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
-import org.springframework.web.server.ResponseStatusException
 import uk.gov.justice.digital.hmpps.hmppsnonassociationsapi.config.ErrorResponse
 import uk.gov.justice.digital.hmpps.hmppsnonassociationsapi.config.NonAssociationNotFoundException
 import uk.gov.justice.digital.hmpps.hmppsnonassociationsapi.dto.CloseNonAssociationRequest
@@ -149,7 +149,7 @@ class NonAssociationsResource(
     sortDirection: Sort.Direction?,
   ): PrisonerNonAssociations {
     val inclusion = NonAssociationListInclusion.of(includeOpen, includeClosed)
-      ?: throw ResponseStatusException(HttpStatus.BAD_REQUEST, "includeOpen and includeClosed cannot both be false")
+      ?: throw ValidationException("includeOpen and includeClosed cannot both be false")
 
     return nonAssociationsService.getPrisonerNonAssociations(
       prisonerNumber,
@@ -262,10 +262,10 @@ class NonAssociationsResource(
     pageable: Pageable,
   ): Page<NonAssociation> {
     if (pageable.pageSize > 200) {
-      throw ResponseStatusException(HttpStatus.BAD_REQUEST, "Page size must be 200 or less")
+      throw ValidationException("Page size must be 200 or less")
     }
     val inclusion = NonAssociationListInclusion.of(includeOpen, includeClosed)
-      ?: throw ResponseStatusException(HttpStatus.BAD_REQUEST, "includeOpen and includeClosed cannot both be false")
+      ?: throw ValidationException("includeOpen and includeClosed cannot both be false")
 
     return nonAssociationsService.getNonAssociations(inclusion, pageable)
   }
@@ -383,11 +383,11 @@ class NonAssociationsResource(
   ): List<NonAssociation> {
     val distinctPrisonerNumbers = prisonerNumbers?.toSet()?.filter { it.isNotEmpty() }
     if (distinctPrisonerNumbers == null || distinctPrisonerNumbers.size < 2) {
-      throw ResponseStatusException(HttpStatus.BAD_REQUEST, "Two or more distinct prisoner numbers are required")
+      throw ValidationException("Two or more distinct prisoner numbers are required")
     }
 
     val inclusion = NonAssociationListInclusion.of(includeOpen, includeClosed)
-      ?: throw ResponseStatusException(HttpStatus.BAD_REQUEST, "includeOpen and includeClosed cannot both be false")
+      ?: throw ValidationException("includeOpen and includeClosed cannot both be false")
 
     return nonAssociationsService.getAnyBetween(prisonerNumbers, inclusion, prisonId)
   }
@@ -468,11 +468,11 @@ class NonAssociationsResource(
   ): List<NonAssociation> {
     val distinctPrisonerNumbers = prisonerNumbers?.toSet()?.filter { it.isNotEmpty() }
     if (distinctPrisonerNumbers.isNullOrEmpty()) {
-      throw ResponseStatusException(HttpStatus.BAD_REQUEST, "One or more distinct prisoner numbers are required")
+      throw ValidationException("One or more distinct prisoner numbers are required")
     }
 
     val inclusion = NonAssociationListInclusion.of(includeOpen, includeClosed)
-      ?: throw ResponseStatusException(HttpStatus.BAD_REQUEST, "includeOpen and includeClosed cannot both be false")
+      ?: throw ValidationException("includeOpen and includeClosed cannot both be false")
 
     return nonAssociationsService.getAnyInvolving(prisonerNumbers, inclusion, prisonId)
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/resource/NonAssociationsResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/resource/NonAssociationsResourceTest.kt
@@ -130,13 +130,13 @@ class NonAssociationsResourceTest : SqsIntegrationTestBase() {
     }
 
     @Test
-    fun `without a valid request body responds 400 Bad Request`() {
+    fun `without a valid request body responds 400 Bad Request or 415 Unsupported Media Type`() {
       // no request body
       webTestClient.post()
         .uri(url)
         .headers(
           setAuthorisation(
-            roles = listOf("ROLE_NON_ASSOCIATIONS"),
+            roles = listOf("ROLE_WRITE_NON_ASSOCIATIONS"),
             scopes = listOf("write"),
           ),
         )
@@ -150,7 +150,7 @@ class NonAssociationsResourceTest : SqsIntegrationTestBase() {
         .uri(url)
         .headers(
           setAuthorisation(
-            roles = listOf("ROLE_NON_ASSOCIATIONS"),
+            roles = listOf("ROLE_WRITE_NON_ASSOCIATIONS"),
             scopes = listOf("write"),
           ),
         )
@@ -158,19 +158,19 @@ class NonAssociationsResourceTest : SqsIntegrationTestBase() {
         .bodyValue("{}")
         .exchange()
         .expectStatus()
-        .isBadRequest
+        .isEqualTo(415)
 
       // request body missing some fields
       webTestClient.post()
         .uri(url)
         .headers(
           setAuthorisation(
-            roles = listOf("ROLE_NON_ASSOCIATIONS"),
+            roles = listOf("ROLE_WRITE_NON_ASSOCIATIONS"),
             scopes = listOf("write"),
           ),
         )
-        .header("Content-Type", "text/plain")
-        .bodyValue(jsonString("firstPrisonerNumber" to "A1234BC"))
+        .header("Content-Type", "application/json")
+        .bodyValue(jsonString(mapOf("firstPrisonerNumber" to "A1234BC")))
         .exchange()
         .expectStatus()
         .isBadRequest
@@ -482,14 +482,14 @@ class NonAssociationsResourceTest : SqsIntegrationTestBase() {
     }
 
     @Test
-    fun `without a valid request body responds 400 Bad Request`() {
+    fun `without a valid request body responds 400 Bad Request or 415 Unsupported Media Type`() {
       // TODO: How do we check the request body is not empty if all fields optional?
       // no request body
       webTestClient.patch()
         .uri(url)
         .headers(
           setAuthorisation(
-            roles = listOf("ROLE_NON_ASSOCIATIONS"),
+            roles = listOf("ROLE_WRITE_NON_ASSOCIATIONS"),
             scopes = listOf("write"),
           ),
         )
@@ -503,7 +503,7 @@ class NonAssociationsResourceTest : SqsIntegrationTestBase() {
         .uri(url)
         .headers(
           setAuthorisation(
-            roles = listOf("ROLE_NON_ASSOCIATIONS"),
+            roles = listOf("ROLE_WRITE_NON_ASSOCIATIONS"),
             scopes = listOf("write"),
           ),
         )
@@ -511,19 +511,19 @@ class NonAssociationsResourceTest : SqsIntegrationTestBase() {
         .bodyValue("{}")
         .exchange()
         .expectStatus()
-        .isBadRequest
+        .isEqualTo(415)
 
       // request body has invalid fields
       webTestClient.patch()
         .uri(url)
         .headers(
           setAuthorisation(
-            roles = listOf("ROLE_NON_ASSOCIATIONS"),
+            roles = listOf("ROLE_WRITE_NON_ASSOCIATIONS"),
             scopes = listOf("write"),
           ),
         )
-        .header("Content-Type", "text/plain")
-        .bodyValue(jsonString("firstPrisonerNumber" to "A1234BC"))
+        .header("Content-Type", "application/json")
+        .bodyValue(jsonString(mapOf("firstPrisonerRole" to "missing")))
         .exchange()
         .expectStatus()
         .isBadRequest
@@ -1068,13 +1068,13 @@ class NonAssociationsResourceTest : SqsIntegrationTestBase() {
     }
 
     @Test
-    fun `without a valid request body responds 400 Bad Request`() {
+    fun `without a valid request body responds 400 Bad Request or 415 Unsupported Media Type`() {
       // no request body
       webTestClient.put()
         .uri(format(url, nonAssociation.id))
         .headers(
           setAuthorisation(
-            roles = listOf("ROLE_NON_ASSOCIATIONS"),
+            roles = listOf("ROLE_WRITE_NON_ASSOCIATIONS"),
             scopes = listOf("write"),
           ),
         )
@@ -1088,7 +1088,7 @@ class NonAssociationsResourceTest : SqsIntegrationTestBase() {
         .uri(format(url, nonAssociation.id))
         .headers(
           setAuthorisation(
-            roles = listOf("ROLE_NON_ASSOCIATIONS"),
+            roles = listOf("ROLE_WRITE_NON_ASSOCIATIONS"),
             scopes = listOf("write"),
           ),
         )
@@ -1096,19 +1096,19 @@ class NonAssociationsResourceTest : SqsIntegrationTestBase() {
         .bodyValue("{}")
         .exchange()
         .expectStatus()
-        .isBadRequest
+        .isEqualTo(415)
 
       // request body has invalid fields
       webTestClient.put()
         .uri(format(url, nonAssociation.id))
         .headers(
           setAuthorisation(
-            roles = listOf("ROLE_NON_ASSOCIATIONS"),
+            roles = listOf("ROLE_WRITE_NON_ASSOCIATIONS"),
             scopes = listOf("write"),
           ),
         )
-        .header("Content-Type", "text/plain")
-        .bodyValue(jsonString("closedBy" to "TEST"))
+        .header("Content-Type", "application/json")
+        .bodyValue(jsonString(mapOf("closedBy" to "TEST")))
         .exchange()
         .expectStatus()
         .isBadRequest
@@ -1246,7 +1246,7 @@ class NonAssociationsResourceTest : SqsIntegrationTestBase() {
     }
 
     @Test
-    fun `without a valid request body responds 400 Bad Request`() {
+    fun `without a valid request body responds 400 Bad Request or 415 Unsupported Media Type`() {
       // no request body
       webTestClient.put()
         .uri(format(url, naToBeReopened.id))
@@ -1274,7 +1274,7 @@ class NonAssociationsResourceTest : SqsIntegrationTestBase() {
         .bodyValue("{}")
         .exchange()
         .expectStatus()
-        .isBadRequest
+        .isEqualTo(415)
 
       // request body has invalid fields
       webTestClient.put()
@@ -1285,8 +1285,8 @@ class NonAssociationsResourceTest : SqsIntegrationTestBase() {
             scopes = listOf("write"),
           ),
         )
-        .header("Content-Type", "text/plain")
-        .bodyValue(jsonString("dummy" to "TEST"))
+        .header("Content-Type", "application/json")
+        .bodyValue(jsonString(mapOf("dummy" to "TEST")))
         .exchange()
         .expectStatus()
         .isBadRequest
@@ -1421,7 +1421,7 @@ class NonAssociationsResourceTest : SqsIntegrationTestBase() {
     }
 
     @Test
-    fun `without a valid request body responds 400 Bad Request`() {
+    fun `without a valid request body responds 400 Bad Request or 415 Unsupported Media Type`() {
       // no request body
       webTestClient.post()
         .uri(format(url, nonAssociation.id))
@@ -1449,7 +1449,7 @@ class NonAssociationsResourceTest : SqsIntegrationTestBase() {
         .bodyValue("{}")
         .exchange()
         .expectStatus()
-        .isBadRequest
+        .isEqualTo(415)
 
       // request body has invalid fields
       webTestClient.post()
@@ -1460,8 +1460,8 @@ class NonAssociationsResourceTest : SqsIntegrationTestBase() {
             scopes = listOf("write"),
           ),
         )
-        .header("Content-Type", "text/plain")
-        .bodyValue(jsonString("staffUserNameRequestingDeletion" to "TEST"))
+        .header("Content-Type", "application/json")
+        .bodyValue(jsonString(mapOf("staffUserNameRequestingDeletion" to "TEST")))
         .exchange()
         .expectStatus()
         .isBadRequest

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/resource/SyncResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/resource/SyncResourceTest.kt
@@ -69,7 +69,7 @@ class SyncResourceTest : SqsIntegrationTestBase() {
     }
 
     @Test
-    fun `without a valid request body responds 400 Bad Request`() {
+    fun `without a valid request body responds 415 Unsupported Media Type`() {
       // no request body
       webTestClient.put()
         .uri(url)
@@ -95,7 +95,7 @@ class SyncResourceTest : SqsIntegrationTestBase() {
         .bodyValue("{}")
         .exchange()
         .expectStatus()
-        .isBadRequest
+        .isEqualTo(415)
 
       // request body missing some fields
       webTestClient.put()
@@ -106,7 +106,7 @@ class SyncResourceTest : SqsIntegrationTestBase() {
           ),
         )
         .header("Content-Type", "application/json")
-        .bodyValue(jsonString("firstPrisonerNumber" to "A1234BC"))
+        .bodyValue(jsonString(mapOf("firstPrisonerNumber" to "A1234BC")))
         .exchange()
         .expectStatus()
         .isBadRequest
@@ -595,7 +595,7 @@ class SyncResourceTest : SqsIntegrationTestBase() {
     }
 
     @Test
-    fun `without a valid request body responds 400 Bad Request`() {
+    fun `without a valid request body responds 400 Bad Request or 415 Unsupported Media Type`() {
       // no request body
       webTestClient.put()
         .uri(url)
@@ -621,7 +621,7 @@ class SyncResourceTest : SqsIntegrationTestBase() {
         .bodyValue("{}")
         .exchange()
         .expectStatus()
-        .isBadRequest
+        .isEqualTo(415)
 
       // request body missing some fields
       webTestClient.put()
@@ -632,7 +632,7 @@ class SyncResourceTest : SqsIntegrationTestBase() {
           ),
         )
         .header("Content-Type", "application/json")
-        .bodyValue(jsonString("firstPrisonerNumber" to "A1234BC"))
+        .bodyValue(jsonString(mapOf("firstPrisonerNumber" to "A1234BC")))
         .exchange()
         .expectStatus()
         .isBadRequest


### PR DESCRIPTION
• Throw `NonAssociationNotFoundException ` instead of _occasionally_ a 404 Not Found `ResponseStatusException` – slightly changes the error response text
• Return 415 Unsupported Media Type instead of 400 Bad Request when the request’s content type is incorrect
• Fix tests for invalid body checking that used incorrect roles or tuples instead of maps
• Throw `ValidationException` instead of 400 Bad Request `ResponseStatusException` so the meaning is more consistent – slightly changes error response `userMessage` text

While some error response text changes slightly, this shouldn't matter to clients as they wouldn't display it to users directly. Similarly, 415 instead of 400 is the more appropriate status for incorrect content types and nobody would have relied on this.