### PR TITLE
Publish node REST client to npmjs.com

### DIFF
--- a/.github/workflows/publish-node-client.yml
+++ b/.github/workflows/publish-node-client.yml
@@ -8,6 +8,7 @@ jobs:
     permissions:
       contents: write
       packages: write
+      id-token: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -24,10 +25,12 @@ jobs:
           echo "Will publish version $version"
           sed -i 's/"version": "0.0.0"/"version": "'$version'"/' package.json
           echo "version=$version" >> "$GITHUB_ENV"
-      - name: Setup node
+      - name: Setup node with private registry
         uses: actions/setup-node@v4
         with:
-          node-version: '18.x'
+          node-version: 20
+          cache: npm
+          cache-dependency-path: clients/node/package-lock.json
           registry-url: 'https://npm.pkg.github.com'
           scope: '@ministryofjustice'
       - name: Install dependencies
@@ -40,6 +43,7 @@ jobs:
           npm test
       - name: Build library
         run: |
+          cp LICENSE clients/node
           cd clients/node
           npm run clean
           npm run build
@@ -57,3 +61,17 @@ jobs:
           npm publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Setup node with public registry
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: clients/node/package-lock.json
+          registry-url: 'https://registry.npmjs.org'
+          scope: '@ministryofjustice'
+      - name: Publish package to npmjs.com
+        run: |
+          cd clients/node
+          npm publish --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2020-2023 Crown Copyright (Ministry of Justice)
+Copyright (c) 2020-2024 Crown Copyright (Ministry of Justice)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/clients/node/.gitignore
+++ b/clients/node/.gitignore
@@ -2,4 +2,5 @@
 /dist/
 /node_modules/
 /test_results/
+LICENSE
 .eslintcache

--- a/clients/node/README.md
+++ b/clients/node/README.md
@@ -10,9 +10,24 @@ Using the library
 
 Typescript applications can install the library in several ways:
 
+### Install from npmjs.com
+
+This is the simplest method.
+
+```shell
+npm install --save @ministryofjustice/hmpps-non-associations-api
+```
+
+Pros:
+- uses the most standard, public registry
+- dependency upgrade tools will process new releases
+
+Cons:
+- publishing requires access token
+
 ### Install from GitHub Releases
 
-This is the recommended method currently.
+This is a fallback method in case we lose ability to publish to npmjs.com.
 
 Find the [latest release version](https://github.com/ministryofjustice/hmpps-non-associations-api/releases)
 and copy the link to the `node-client.tgz` asset.


### PR DESCRIPTION
Version 0.4.0 was already manually published to [npmjs.com](https://www.npmjs.com/package/@ministryofjustice/hmpps-non-associations-api)