### PR TITLE
Revert "Update Helm release generic-prometheus-alerts to 1.4"

### DIFF
--- a/helm_deploy/hmpps-non-associations-api/Chart.yaml
+++ b/helm_deploy/hmpps-non-associations-api/Chart.yaml
@@ -8,5 +8,5 @@ dependencies:
     version: '2.9'
     repository: https://ministryofjustice.github.io/hmpps-helm-charts
   - name: generic-prometheus-alerts
-    version: '1.4'
+    version: '1.3'
     repository: https://ministryofjustice.github.io/hmpps-helm-charts


### PR DESCRIPTION
Reverts ministryofjustice/hmpps-non-associations-api#227

See: https://mojdt.slack.com/archives/C69NWE339/p1708939446415199