### PR TITLE
NON-347: Format `close_date` like other dates

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -21,7 +21,7 @@ dependencies {
   implementation("org.springframework.boot:spring-boot-starter-validation")
 
   implementation("uk.gov.justice.service.hmpps:hmpps-sqs-spring-boot-starter:3.1.1")
-  implementation("uk.gov.justice.service.hmpps:hmpps-digital-prison-reporting-lib:3.7.0")
+  implementation("uk.gov.justice.service.hmpps:hmpps-digital-prison-reporting-lib:3.7.1")
 
   implementation("io.opentelemetry:opentelemetry-api:1.36.0")
   implementation("io.opentelemetry.instrumentation:opentelemetry-instrumentation-annotations:2.2.0")

--- a/src/main/resources/definitions.json
+++ b/src/main/resources/definitions.json
@@ -249,6 +249,7 @@
           {
             "name": "$ref:closed_date",
             "display": "Close Date",
+            "formula" : "format_date(${created_date}, 'dd/MM/yyyy')",
             "sortable": true,
             "defaultsort": false
           }


### PR DESCRIPTION
This is now possible because DPR library has fixed problem causing exceptions when the date was null:

https://github.com/ministryofjustice/hmpps-digital-prison-reporting-lib/issues/122