### PR TITLE
NON-347: Use boolean type for `is_closed` field

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -21,7 +21,7 @@ dependencies {
   implementation("org.springframework.boot:spring-boot-starter-validation")
 
   implementation("uk.gov.justice.service.hmpps:hmpps-sqs-spring-boot-starter:3.1.1")
-  implementation("uk.gov.justice.service.hmpps:hmpps-digital-prison-reporting-lib:3.7.1")
+  implementation("uk.gov.justice.service.hmpps:hmpps-digital-prison-reporting-lib:3.7.2")
 
   implementation("io.opentelemetry:opentelemetry-api:1.36.0")
   implementation("io.opentelemetry.instrumentation:opentelemetry-instrumentation-annotations:2.2.0")

--- a/src/main/resources/definitions.json
+++ b/src/main/resources/definitions.json
@@ -18,7 +18,7 @@
     {
       "id": "all",
       "name": "All",
-      "query": "SELECT na.first_prisoner_number, na.first_prisoner_role, na.second_prisoner_number, na.second_prisoner_role, na.reason, na.restriction_type, na.when_created AS created_date, na.when_updated AS updated_date, TEXT(na.is_closed) AS is_closed, na.closed_at AS closed_date FROM non_association AS na ORDER BY na.when_created DESC",
+      "query": "SELECT na.first_prisoner_number, na.first_prisoner_role, na.second_prisoner_number, na.second_prisoner_role, na.reason, na.restriction_type, na.when_created AS created_date, na.when_updated AS updated_date, na.is_closed, na.closed_at AS closed_date FROM non_association AS na ORDER BY na.when_created DESC",
       "schema": {
         "field": [
           {
@@ -55,7 +55,7 @@
           },
           {
             "name": "is_closed",
-            "type": "string"
+            "type": "boolean"
           },
           {
             "name": "closed_date",
@@ -236,11 +236,11 @@
               "default": "false",
               "staticoptions": [
                 {
-                  "name": "false",
+                  "name": false,
                   "display": "Only open"
                 },
                 {
-                  "name": "true",
+                  "name": true,
                   "display": "Only closed"
                 }
               ]


### PR DESCRIPTION
DPR support for filtering was added in version `3.7.2`: https://github.com/ministryofjustice/hmpps-digital-prison-reporting-lib/blob/main/CHANGELOG.md#372