### PR TITLE
NON-358: SAR endpoint responds `204 No Content` when no information matching

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/config/HmppsNonAssociationsApiExceptionHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/config/HmppsNonAssociationsApiExceptionHandler.kt
@@ -9,6 +9,7 @@ import org.springframework.http.HttpStatus.BAD_REQUEST
 import org.springframework.http.HttpStatus.CONFLICT
 import org.springframework.http.HttpStatus.FORBIDDEN
 import org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR
+import org.springframework.http.HttpStatus.NO_CONTENT
 import org.springframework.http.HttpStatus.NOT_FOUND
 import org.springframework.http.HttpStatus.UNAUTHORIZED
 import org.springframework.http.HttpStatus.UNSUPPORTED_MEDIA_TYPE
@@ -112,6 +113,20 @@ class HmppsNonAssociationsApiExceptionHandler {
         ErrorResponse(
           status = NOT_FOUND,
           userMessage = "Not Found: ${e.message}",
+          developerMessage = e.message,
+        ),
+      )
+  }
+
+  @ExceptionHandler(SubjectAccessRequestNoContentException::class)
+  fun handleSubjectAccessRequestNoContentException(e: SubjectAccessRequestNoContentException): ResponseEntity<ErrorResponse?>? {
+    log.debug("SAR No Content exception caught: {}", e.message)
+    return ResponseEntity
+      .status(NO_CONTENT)
+      .body(
+        ErrorResponse(
+          status = NO_CONTENT,
+          userMessage = "No Content: ${e.message}",
           developerMessage = e.message,
         ),
       )
@@ -321,3 +336,5 @@ class OpenNonAssociationAlreadyExistsException(prisoners: List<String>) : Except
 class NonAssociationNotFoundException(id: Long) : Exception("There is no non-association found for ID = $id")
 
 class NullPrisonerLocationsException(prisoners: List<String>) : Exception("Prisoners $prisoners have null locations")
+
+class SubjectAccessRequestNoContentException(prisoner: String) : Exception("No information on prisoner $prisoner")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/config/HmppsNonAssociationsApiExceptionHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/config/HmppsNonAssociationsApiExceptionHandler.kt
@@ -9,8 +9,8 @@ import org.springframework.http.HttpStatus.BAD_REQUEST
 import org.springframework.http.HttpStatus.CONFLICT
 import org.springframework.http.HttpStatus.FORBIDDEN
 import org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR
-import org.springframework.http.HttpStatus.NO_CONTENT
 import org.springframework.http.HttpStatus.NOT_FOUND
+import org.springframework.http.HttpStatus.NO_CONTENT
 import org.springframework.http.HttpStatus.UNAUTHORIZED
 import org.springframework.http.HttpStatus.UNSUPPORTED_MEDIA_TYPE
 import org.springframework.http.ResponseEntity

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/service/SubjectAccessRequestService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/service/SubjectAccessRequestService.kt
@@ -1,7 +1,6 @@
 package uk.gov.justice.digital.hmpps.hmppsnonassociationsapi.service
 
 import org.springframework.stereotype.Service
-import org.springframework.web.reactive.function.client.WebClientResponseException.NotFound
 import uk.gov.justice.digital.hmpps.hmppsnonassociationsapi.config.SubjectAccessRequestNoContentException
 import uk.gov.justice.digital.hmpps.hmppsnonassociationsapi.dto.NonAssociationListInclusion
 import uk.gov.justice.digital.hmpps.hmppsnonassociationsapi.dto.NonAssociationListOptions
@@ -21,11 +20,7 @@ class SubjectAccessRequestService(
   ): HmppsSubjectAccessRequestContent? {
     val options = NonAssociationListOptions(includeOtherPrisons = true, inclusion = NonAssociationListInclusion.ALL)
 
-    val nonAssociations = try {
-      nonAssociationsService.getPrisonerNonAssociations(prn, options)
-    } catch (e: NotFound) {
-      throw SubjectAccessRequestNoContentException(prn)
-    }
+    val nonAssociations = nonAssociationsService.getPrisonerNonAssociations(prn, options)
 
     // Filter non-associations by given date range
     val content = nonAssociations.copy(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/service/SubjectAccessRequestService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/service/SubjectAccessRequestService.kt
@@ -1,6 +1,8 @@
 package uk.gov.justice.digital.hmpps.hmppsnonassociationsapi.service
 
 import org.springframework.stereotype.Service
+import org.springframework.web.reactive.function.client.WebClientResponseException.NotFound
+import uk.gov.justice.digital.hmpps.hmppsnonassociationsapi.config.SubjectAccessRequestNoContentException
 import uk.gov.justice.digital.hmpps.hmppsnonassociationsapi.dto.NonAssociationListInclusion
 import uk.gov.justice.digital.hmpps.hmppsnonassociationsapi.dto.NonAssociationListOptions
 import uk.gov.justice.hmpps.kotlin.sar.HmppsPrisonSubjectAccessRequestService
@@ -18,14 +20,25 @@ class SubjectAccessRequestService(
     toDate: LocalDate?,
   ): HmppsSubjectAccessRequestContent? {
     val options = NonAssociationListOptions(includeOtherPrisons = true, inclusion = NonAssociationListInclusion.ALL)
-    val nonAssociations = nonAssociationsService.getPrisonerNonAssociations(prn, options)
 
-    return HmppsSubjectAccessRequestContent(
-      content = nonAssociations.copy(
-        nonAssociations = nonAssociations.nonAssociations.filter {
-          (fromDate == null || it.whenCreated.toLocalDate().isAfter(fromDate)) && (toDate == null || it.whenCreated.toLocalDate().isBefore(toDate))
-        },
-      ),
+    val nonAssociations = try {
+      nonAssociationsService.getPrisonerNonAssociations(prn, options)
+    } catch (e: NotFound)  {
+      throw SubjectAccessRequestNoContentException(prn)
+    }
+
+    // Filter non-associations by given date range
+    val content = nonAssociations.copy(
+      nonAssociations = nonAssociations.nonAssociations.filter {
+        (fromDate == null || it.whenCreated.toLocalDate().isAfter(fromDate)) && (toDate == null || it.whenCreated.toLocalDate().isBefore(toDate))
+      },
     )
+
+    if (content.nonAssociations.isEmpty()) {
+      // No non-associations in given date range
+      throw SubjectAccessRequestNoContentException(prn)
+    }
+
+    return HmppsSubjectAccessRequestContent(content)
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/service/SubjectAccessRequestService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/service/SubjectAccessRequestService.kt
@@ -23,7 +23,7 @@ class SubjectAccessRequestService(
 
     val nonAssociations = try {
       nonAssociationsService.getPrisonerNonAssociations(prn, options)
-    } catch (e: NotFound)  {
+    } catch (e: NotFound) {
       throw SubjectAccessRequestNoContentException(prn)
     }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/resource/NonAssociationsResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/resource/NonAssociationsResourceTest.kt
@@ -3309,7 +3309,12 @@ class NonAssociationsResourceTest : SqsIntegrationTestBase() {
   @Test
   fun `when SAR about prisoner with no non-associations, responds 204 No Content`() {
     // Someone with no non-associations
-    val prisonerNumber = "A1111AA"
+    val prisonerNumber = "G9012HI"
+
+    offenderSearchMockServer.stubSearchByPrisonerNumbers(
+      listOf(prisonerNumber),
+      listOf(offenderSearchPrisoners[prisonerNumber]!!),
+    )
 
     webTestClient.get()
       .uri("/subject-access-request?prn=$prisonerNumber")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/resource/NonAssociationsResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/resource/NonAssociationsResourceTest.kt
@@ -3312,7 +3312,7 @@ class NonAssociationsResourceTest : SqsIntegrationTestBase() {
     val prisonerNumber = "A1111AA"
 
     webTestClient.get()
-      .uri("/subject-access-request?prn=${prisonerNumber}")
+      .uri("/subject-access-request?prn=$prisonerNumber")
       .headers(setAuthorisation(roles = listOf("ROLE_SAR_DATA_ACCESS")))
       .header("Content-Type", "application/json")
       .exchange()


### PR DESCRIPTION
The endpoint now responds `204 No Content` when no non-associations for the given prisoner were found or when none of them were within the given date range.

**NOTE**: Offender Search API could _potentially_ not have information on some of the prisoners involved in the non-associations found. This is an edge case but without these information (names, etc...) we cannot construct the response correctly so the endpoint will continue to respond `404 Not Found` in these cases.

In my opinion this is better than responding `204 No Content` and misleading the client into believing there were no information on the given subject. It shouldn't happen in theory anyway.