### PR TITLE
NON-358: OS service throws a specific exception when some prisoners are missing

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/config/HmppsNonAssociationsApiExceptionHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/config/HmppsNonAssociationsApiExceptionHandler.kt
@@ -161,6 +161,20 @@ class HmppsNonAssociationsApiExceptionHandler {
       )
   }
 
+  @ExceptionHandler(MissingPrisonersInSearchException::class)
+  fun handleMissingPrisonersInSearchException(e: MissingPrisonersInSearchException): ResponseEntity<ErrorResponse?>? {
+    log.debug("Missing prisoners in Offender Search API: {}", e.message)
+    return ResponseEntity
+      .status(NOT_FOUND)
+      .body(
+        ErrorResponse(
+          status = NOT_FOUND,
+          userMessage = "Missing prisoners: ${e.message}",
+          developerMessage = e.message,
+        ),
+      )
+  }
+
   @ExceptionHandler(ResponseStatusException::class)
   fun handleResponseStatusException(e: ResponseStatusException): ResponseEntity<ErrorResponse?>? {
     log.debug("Response status exception caught: {}", e.message)
@@ -338,3 +352,5 @@ class NonAssociationNotFoundException(id: Long) : Exception("There is no non-ass
 class NullPrisonerLocationsException(prisoners: List<String>) : Exception("Prisoners $prisoners have null locations")
 
 class SubjectAccessRequestNoContentException(prisoner: String) : Exception("No information on prisoner $prisoner")
+
+class MissingPrisonersInSearchException(prisoners: Iterable<String>) : Exception("Could not find the following prisoners: $prisoners")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/service/OffenderSearchService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/service/OffenderSearchService.kt
@@ -1,10 +1,9 @@
 package uk.gov.justice.digital.hmpps.hmppsnonassociationsapi.service
 
-import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Service
 import org.springframework.web.reactive.function.client.WebClient
 import org.springframework.web.reactive.function.client.bodyToMono
-import org.springframework.web.server.ResponseStatusException
+import uk.gov.justice.digital.hmpps.hmppsnonassociationsapi.config.MissingPrisonersInSearchException
 import uk.gov.justice.digital.hmpps.hmppsnonassociationsapi.dto.offendersearch.OffenderSearchPrisoner
 
 @Service
@@ -34,10 +33,7 @@ class OffenderSearchService(
     // Throw an exception if any of the prisoners searched were not found
     val missingPrisoners = prisonerNumbers.subtract(foundPrisoners.keys)
     if (missingPrisoners.any()) {
-      throw ResponseStatusException(
-        HttpStatus.NOT_FOUND,
-        "Could not find the following prisoners: $missingPrisoners",
-      )
+      throw MissingPrisonersInSearchException(missingPrisoners)
     }
 
     return foundPrisoners

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/resource/NonAssociationsResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/resource/NonAssociationsResourceTest.kt
@@ -213,7 +213,7 @@ class NonAssociationsResourceTest : SqsIntegrationTestBase() {
         .expectStatus().isNotFound
         .expectBody()
         .jsonPath("userMessage").isEqualTo(
-          "Could not find the following prisoners: [X1111TT]",
+          "Missing prisoners: Could not find the following prisoners: [X1111TT]",
         )
     }
 
@@ -1984,7 +1984,7 @@ class NonAssociationsResourceTest : SqsIntegrationTestBase() {
         .expectStatus().isNotFound
         .expectBody()
         .jsonPath("userMessage")
-        .isEqualTo("Could not find the following prisoners: [${nonAssociation.firstPrisonerNumber}, ${nonAssociation.secondPrisonerNumber}]")
+        .isEqualTo("Missing prisoners: Could not find the following prisoners: [${nonAssociation.firstPrisonerNumber}, ${nonAssociation.secondPrisonerNumber}]")
     }
 
     @Test


### PR DESCRIPTION
Instead of throwing a generic `NotFound` exception. This potentially allows the handling of this case differently if required.

It should fix https://github.com/ministryofjustice/hmpps-non-associations-api/issues/258