### PR TITLE
NON-358: SAR: Respond 209 when a prisoner is not found (in OS API)

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/config/HmppsNonAssociationsApiExceptionHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/config/HmppsNonAssociationsApiExceptionHandler.kt
@@ -132,6 +132,20 @@ class HmppsNonAssociationsApiExceptionHandler {
       )
   }
 
+  @ExceptionHandler(SubjectAccessRequestSubjectNotRecognisedException::class)
+  fun handleSubjectAccessRequestSubjectNotRecognisedException(e: SubjectAccessRequestSubjectNotRecognisedException): ResponseEntity<ErrorResponse?>? {
+    log.debug("SAR Subject not recognised exception caught: {}", e.message)
+    return ResponseEntity
+      .status(209)
+      .body(
+        ErrorResponse(
+          status = 209,
+          userMessage = e.message!!,
+          developerMessage = e.message!!,
+        ),
+      )
+  }
+
   @ExceptionHandler(NoResourceFoundException::class)
   fun handleNoResourceFoundException(e: NoResourceFoundException): ResponseEntity<ErrorResponse?>? {
     log.debug("No resource found exception caught: {}", e.message)
@@ -352,5 +366,7 @@ class NonAssociationNotFoundException(id: Long) : Exception("There is no non-ass
 class NullPrisonerLocationsException(prisoners: List<String>) : Exception("Prisoners $prisoners have null locations")
 
 class SubjectAccessRequestNoContentException(prisoner: String) : Exception("No information on prisoner $prisoner")
+
+class SubjectAccessRequestSubjectNotRecognisedException : Exception("Subject Identifier is not recognised by this service")
 
 class MissingPrisonersInSearchException(prisoners: Iterable<String>) : Exception("Could not find the following prisoners: $prisoners")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/service/SubjectAccessRequestService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/service/SubjectAccessRequestService.kt
@@ -1,7 +1,9 @@
 package uk.gov.justice.digital.hmpps.hmppsnonassociationsapi.service
 
 import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.hmppsnonassociationsapi.config.MissingPrisonersInSearchException
 import uk.gov.justice.digital.hmpps.hmppsnonassociationsapi.config.SubjectAccessRequestNoContentException
+import uk.gov.justice.digital.hmpps.hmppsnonassociationsapi.config.SubjectAccessRequestSubjectNotRecognisedException
 import uk.gov.justice.digital.hmpps.hmppsnonassociationsapi.dto.NonAssociationListInclusion
 import uk.gov.justice.digital.hmpps.hmppsnonassociationsapi.dto.NonAssociationListOptions
 import uk.gov.justice.hmpps.kotlin.sar.HmppsPrisonSubjectAccessRequestService
@@ -20,7 +22,11 @@ class SubjectAccessRequestService(
   ): HmppsSubjectAccessRequestContent? {
     val options = NonAssociationListOptions(includeOtherPrisons = true, inclusion = NonAssociationListInclusion.ALL)
 
-    val nonAssociations = nonAssociationsService.getPrisonerNonAssociations(prn, options)
+    val nonAssociations = try {
+      nonAssociationsService.getPrisonerNonAssociations(prn, options)
+    } catch (e: MissingPrisonersInSearchException) {
+      throw SubjectAccessRequestSubjectNotRecognisedException()
+    }
 
     // Filter non-associations by given date range
     val content = nonAssociations.copy(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/resource/NonAssociationsResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/resource/NonAssociationsResourceTest.kt
@@ -3350,10 +3350,9 @@ class NonAssociationsResourceTest : SqsIntegrationTestBase() {
   }
 
   @Test
-  fun `when SAR about prisoner with non-associations, but Offender Search doesn't know them, still responds 404 Not Found`() {
-    // Upstream problems with Offender Search API still lead with a 404 Not Found
-    // This is likely temporary and nothing to do with non-associations so we shouldn't
-    // mislead the clients by saying "no information on this subject"
+  fun `when SAR about prisoner with non-associations, but Offender Search doesn't know them, responds 209`() {
+    // A prisoner number not found in Offender Search API is different than "no non-associations found for this prisoner"
+    // and that's why it's not a 204 No Content: Responds 209 Subject Identifier is not recognised by this service.
     val nonAssociation = createNonAssociation()
 
     offenderSearchMockServer.stubSearchByPrisonerNumbers(
@@ -3369,7 +3368,7 @@ class NonAssociationsResourceTest : SqsIntegrationTestBase() {
       .headers(setAuthorisation(roles = listOf("ROLE_SAR_DATA_ACCESS")))
       .header("Content-Type", "application/json")
       .exchange()
-      .expectStatus().isNotFound
+      .expectStatus().isEqualTo(209)
   }
 
   private fun createNonAssociation(


### PR DESCRIPTION
The Subject Access Request (SAR) endpoint was responding `404 Not Found` when a prisoner number was not found in Offender Search API.

However the SAR endpoint contract doesn't expect 404s: https://non-associations-api-dev.hmpps.service.justice.gov.uk/swagger-ui/index.html#/Subject%20Access%20Request/getSarContentByReference

This case is still different than the case where we didn't find non-associations for the subject.

The endpoint now responds `209` "Subject Identifier is not recognised by this service" in this case.