### PR TITLE
NON-318: Send alerts to dev channel

### DIFF
--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -16,7 +16,7 @@ generic-service:
     URL_ENV_SUFFIX: dev
 
 generic-prometheus-alerts:
-  alertSeverity: digital-prison-service-dev
+  alertSeverity: hmpps-non-associations-dev
   businessHoursOnly: true
   rdsAlertsDatabases:
     cloud-platform-7534158a562cce9e: non-associations-api

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -14,7 +14,7 @@ generic-service:
     URL_ENV_SUFFIX: preprod
 
 generic-prometheus-alerts:
-  alertSeverity: digital-prison-service-dev
+  alertSeverity: hmpps-non-associations-preprod
   businessHoursOnly: true
   rdsAlertsDatabases:
     cloud-platform-b6126468990788eb: non-associations-api

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -21,7 +21,7 @@ generic-service:
         DB_HOST_PREPROD: "rds_instance_address"
 
 generic-prometheus-alerts:
-  alertSeverity: digital-prison-service
+  alertSeverity: hmpps-non-associations-prod
   rdsAlertsDatabases:
     cloud-platform-994c511ab5935ecc: non-associations-api
   sqsAlertsQueueNames:


### PR DESCRIPTION
Send alerts to our Slack dev channel (`#non-associations-dev`) instead of sending them to `#dps_alers`/`#dps_alerts_non_prod`.