### PR TITLE
NON-369: Prevent calling search when no non-associations are found

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/service/OffenderSearchService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/service/OffenderSearchService.kt
@@ -18,6 +18,10 @@ class OffenderSearchService(
   fun searchByPrisonerNumbers(
     prisonerNumbers: Collection<String>,
   ): Map<String, OffenderSearchPrisoner> {
+    if (prisonerNumbers.isEmpty()) {
+      return emptyMap()
+    }
+
     val requestBody = mapOf("prisonerNumbers" to prisonerNumbers.toSet())
 
     val foundPrisoners = offenderSearchWebClient

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/integration/wiremock/OffenderSearchMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/integration/wiremock/OffenderSearchMockServer.kt
@@ -47,4 +47,15 @@ class OffenderSearchMockServer : WireMockServer(WIREMOCK_PORT) {
         ),
     )
   }
+
+  fun stubSearchFails() {
+    stubFor(
+      post("/prisoner-search/prisoner-numbers")
+        .willReturn(
+          aResponse()
+            .withHeader("Content-Type", "application/json")
+            .withStatus(500),
+        ),
+    )
+  }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/resource/NonAssociationsResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/resource/NonAssociationsResourceTest.kt
@@ -2334,6 +2334,25 @@ class NonAssociationsResourceTest : SqsIntegrationTestBase() {
     }
 
     @Test
+    fun `when prisonId is provided and there are no non-associations between the prisoners`() {
+      createNonAssociation("A0011AA", prisonerJohnNumber)
+      // offender search fails when given an empty list of prisoner numbers
+      offenderSearchMockServer.stubSearchFails()
+
+      webTestClient.post()
+        .uri {
+          it.path(urlPath)
+            .queryParam("prisonId", "MDI")
+            .build()
+        }
+        .headers(setAuthorisation(roles = listOf("ROLE_READ_NON_ASSOCIATIONS")))
+        .bodyValue(listOf(prisonerJohnNumber, prisonerMerlinNumber))
+        .exchange()
+        .expectStatus().isOk
+        .expectBody().json("[]", true)
+    }
+
+    @Test
     fun `when there are non-associations between the prisoners`() {
       createNonAssociation()
       createNonAssociation(isClosed = true)
@@ -2683,6 +2702,25 @@ class NonAssociationsResourceTest : SqsIntegrationTestBase() {
 
       webTestClient.post()
         .uri(urlPath)
+        .headers(setAuthorisation(roles = listOf("ROLE_READ_NON_ASSOCIATIONS")))
+        .bodyValue(listOf(prisonerJohnNumber, prisonerMerlinNumber))
+        .exchange()
+        .expectStatus().isOk
+        .expectBody().json("[]", true)
+    }
+
+    @Test
+    fun `when prisonId is provided and there are no non-associations involving the prisoners`() {
+      createNonAssociation("A0011AA", "D4444DD")
+      // offender search fails when given an empty list of prisoner numbers
+      offenderSearchMockServer.stubSearchFails()
+
+      webTestClient.post()
+        .uri {
+          it.path(urlPath)
+            .queryParam("prisonId", "MDI")
+            .build()
+        }
         .headers(setAuthorisation(roles = listOf("ROLE_READ_NON_ASSOCIATIONS")))
         .bodyValue(listOf(prisonerJohnNumber, prisonerMerlinNumber))
         .exchange()


### PR DESCRIPTION
This should fix the problem of propagating an error from offender search into responses from this api that should have returned empty lists of non-associations