### PR TITLE
NON-390 Specify response fields in Offender Search API request

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/service/OffenderSearchService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/service/OffenderSearchService.kt
@@ -28,7 +28,9 @@ class OffenderSearchService(
         val requestBody = mapOf("prisonerNumbers" to pageOfPrisonerNumbers)
         offenderSearchWebClient
           .post()
-          .uri("/prisoner-search/prisoner-numbers")
+          .uri(
+            "/prisoner-search/prisoner-numbers?responseFields=prisonerNumber,firstName,lastName,prisonId,prisonName,cellLocation",
+          )
           .header("Content-Type", "application/json")
           .bodyValue(requestBody)
           .retrieve()


### PR DESCRIPTION
Optimize data retrieval in the Offender Search API by specifying required response fields. This ensures more efficient use of resources when fetching data. 