### PR TITLE
IR-1136: Tweaked start/stop schedule

### DIFF
--- a/helm_deploy/hmpps-non-associations-api/values.yaml
+++ b/helm_deploy/hmpps-non-associations-api/values.yaml
@@ -12,6 +12,10 @@ generic-service:
     tag: app_version    # override at deployment time
     port: 8080
 
+  scheduledDowntime:
+    startup: '49 6 * * 1-5' # Start at 6.49am UTC Monday-Friday
+    shutdown: '58 21 * * 1-5' # Stop at 9.58pm UTC Monday-Friday
+
   retryDlqCronjob:
     enabled: true
 
@@ -68,9 +72,6 @@ generic-service:
     groups:
       - digital_staff_and_mojo
       - moj_cloud_platform
-
-  scheduledDowntime:
-    timeZone: Europe/London
 
 generic-prometheus-alerts:
   targetApplication: hmpps-non-associations-api

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -2,6 +2,9 @@ generic-service:
   ingress:
     host: non-associations-api.hmpps.service.justice.gov.uk
 
+  scheduledDowntime:
+    enabled: false
+
   env:
     API_BASE_URL_OAUTH: https://sign-in.hmpps.service.justice.gov.uk/auth
     API_BASE_URL_PRISONER_SEARCH: https://prisoner-search.prison.service.justice.gov.uk


### PR DESCRIPTION
Use UTC and ensure API starts before UI/first retry-dlq run and stops after UI and last retry-dlq run.

- 6:49am API starts
- 7:00am UI starts
- [7:00am retry-dlq run every 10 minutes](https://github.com/ministryofjustice/hmpps-helm-charts/blob/f210af4475dd27689621b491a63d69bbe683de0e/charts/generic-service/values.yaml#L256)
- ...
- 9:50pm retry-dlq last run for the day
- 9:50pm UI stops
- 9:58pm API stops

**NOTE**: UI PR to tweak its schedules to follow.