### PR TITLE
Fix Renovate's `matchPackageNames`

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,14 +6,14 @@
   "packageRules": [
     {
       "matchManagers": ["gradle"],
-      "matchPackageNames": ["swagger-parser"],
+      "matchPackageNames": ["io.swagger.parser.v3:swagger-parser"],
       "matchUpdateTypes": ["minor", "patch"],
       "groupName": "swagger-parser",
       "groupSlug": "swagger-parser"
     },
     {
       "matchManagers": ["gradle"],
-      "matchPackageNames": ["hmpps-digital-prison-reporting-lib"],
+      "matchPackageNames": ["uk.gov.justice.service.hmpps:hmpps-digital-prison-reporting-lib"],
       "matchUpdateTypes": ["minor", "patch"],
       "groupName": "hmpps-digital-prison-reporting-lib",
       "groupSlug": "hmpps-digital-prison-reporting-lib"


### PR DESCRIPTION
Needs to include all the package name (`group:name`)