### PR TITLE
Renovate: Move more specific rules last

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,6 +6,12 @@
   "packageRules": [
     {
       "matchManagers": ["gradle"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "groupName": "all non major Gradle dependencies",
+      "groupSlug": "all-gradle-minor-patch"
+    },
+    {
+      "matchManagers": ["gradle"],
       "matchPackageNames": ["io.swagger.parser.v3:swagger-parser"],
       "matchUpdateTypes": ["minor", "patch"],
       "groupName": "swagger-parser",
@@ -17,12 +23,6 @@
       "matchUpdateTypes": ["minor", "patch"],
       "groupName": "hmpps-digital-prison-reporting-lib",
       "groupSlug": "hmpps-digital-prison-reporting-lib"
-    },
-    {
-      "matchManagers": ["gradle"],
-      "matchUpdateTypes": ["minor", "patch"],
-      "groupName": "all non major Gradle dependencies",
-      "groupSlug": "all-gradle-minor-patch"
     }
   ]
 }


### PR DESCRIPTION
When multiple rules match the last win, so the
rule that updates all non-major dependencies has to go first as it's matched by the other rules too.