### PR TITLE
Integrating MoJ SLSA GH Action

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -58,6 +58,7 @@ jobs:
     uses: ./.github/workflows/test-node-client.yml
     with:
       node-version: ${{ matrix.node-version }}
+      enable_slsa_action: true
   build:
     name: Build docker image from hmpps-github-actions
     if: github.ref == 'refs/heads/main'

--- a/.github/workflows/publish-node-client.yml
+++ b/.github/workflows/publish-node-client.yml
@@ -34,6 +34,9 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
           scope: '@ministryofjustice'
 
+      - name: SLSA
+        uses: ministryofjustice/devsecops-actions/sca/slsa@4cd163be7859cd130800d6719d925318826038ea # v1
+
       - name: Install dependencies
         run: |
           cd clients/node

--- a/.github/workflows/test-node-client.yml
+++ b/.github/workflows/test-node-client.yml
@@ -2,6 +2,11 @@ name: Test REST client
 on:
   workflow_call:
     inputs:
+      enable_slsa_action:
+        description: Enable dev-sec-ops SLSA action
+        type: boolean
+        required: true
+        default: true
       node-version:
         description: Node version
         required: true
@@ -20,6 +25,10 @@ jobs:
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
           node-version: ${{ inputs.node-version }}
+
+      - name: SLSA
+        if: ${{ inputs.enable_slsa_action }}
+        uses: ministryofjustice/devsecops-actions/sca/slsa@4cd163be7859cd130800d6719d925318826038ea # v1
 
       - name: Install npm dependencies
         shell: bash


### PR DESCRIPTION
The aim of this GH Action is to protect from Supply Chain Attacks, e.g. one of your dependency being replaced by a malicious actor in a way or the the other.

The action would check for things like:
- a package being too recent (and therefore potentially having undiscovered vulnerabilities)
- checking for known vulnerabilities (e.g. CVEs)
- checking for typosquatting attacks (e.g. someone releasing a package with a very similar name of a popular one)
- etc...

**NOTE**: This is fairly new and there are still unanswered questions on how it would work in practice. For example if there is a known vulnerability the action will fail the CI run but if a security patch is too new that may also fail the build. It's an ongoing conversation but some of these questions were asked here: https://mojdt.slack.com/archives/C3F8L6XQU/p1775046487179089?thread_ts=1775032049.634239&cid=C3F8L6XQU

See:
- Docs: https://github.com/ministryofjustice/devsecops-actions/tree/main/sca/slsa
- Slack announcement: https://mojdt.slack.com/archives/C3F8L6XQU/p1775032049634239