### PR TITLE
GHA: Replaced deprecated workflow

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -41,7 +41,7 @@ jobs:
       environment: ${{ matrix.environments }}
   kotlin_validate:
     name: Validate the kotlin
-    uses: ministryofjustice/hmpps-github-actions/.github/workflows/gradle_localstack_postgres_verify.yml@v2 # WORKFLOW_VERSION
+    uses: ministryofjustice/hmpps-github-actions/.github/workflows/gradle_verify.yml@v2 # WORKFLOW_VERSION
     secrets: inherit
     with:
       postgres-tag: '16'


### PR DESCRIPTION
Replaced deprecated HMPPS' `gradle_localstack_postgres_verify` with `gradle_verify`.

See PR that introduced this change/deprecation:
https://github.com/ministryofjustice/hmpps-github-actions/pull/165