### PR TITLE
IR-1611 NonAssociationsMergeService duplicate detection bugs

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/jpa/repository/NonAssociationsRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/jpa/repository/NonAssociationsRepository.kt
@@ -52,12 +52,24 @@ interface NonAssociationsRepository : JpaRepository<NonAssociation, Long> {
     @Param("isClosed") isClosed: Boolean,
   ): List<NonAssociation>
 
-  // TODO: Assumes that there can only be 1 non-association given a pair of prisoner numbers.
-  //       In future, this will only be true for open non-associations.
-  fun findByFirstPrisonerNumberAndSecondPrisonerNumber(
-    firstPrisonerNumber: String,
-    secondPrisonerNumber: String,
-  ): NonAssociation?
+  /**
+   * Finds all open non-associations between two prisoners, regardless of which is first or second.
+   * Used during merge to detect duplicates without being tripped up by closed historical records
+   * or direction-of-storage differences.
+   */
+  @Query(
+    """
+      SELECT n FROM NonAssociation n
+      WHERE n.isClosed = false AND (
+        (n.firstPrisonerNumber = :firstPrisonerNumber AND n.secondPrisonerNumber = :secondPrisonerNumber) OR
+        (n.firstPrisonerNumber = :secondPrisonerNumber AND n.secondPrisonerNumber = :firstPrisonerNumber)
+      )
+    """,
+  )
+  fun findOpenBetweenPrisoners(
+    @Param("firstPrisonerNumber") firstPrisonerNumber: String,
+    @Param("secondPrisonerNumber") secondPrisonerNumber: String,
+  ): List<NonAssociation>
 }
 
 /**

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/service/NonAssociationsMergeService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/service/NonAssociationsMergeService.kt
@@ -70,36 +70,34 @@ class NonAssociationsMergeService(
       .forEach { nonAssociation ->
         log.debug("Looking at record {}", nonAssociation)
         if (nonAssociation.firstPrisonerNumber == oldPrisonerNumber) {
-          nonAssociationsRepository.findByFirstPrisonerNumberAndSecondPrisonerNumber(
+          val duplicateRecord = nonAssociationsRepository.findOpenBetweenPrisoners(
             firstPrisonerNumber = newPrisonerNumber,
             secondPrisonerNumber = nonAssociation.secondPrisonerNumber,
-          ).let { duplicateRecord ->
-            merge(
-              nonAssociation,
-              duplicateRecord,
-              newPrisonerNumber,
-              nonAssociation.secondPrisonerNumber,
-              true,
-            ).let { updatedRecord ->
-              updatedRecords.add(updatedRecord)
-            }
+          ).firstOrNull()
+          merge(
+            nonAssociation,
+            duplicateRecord,
+            newPrisonerNumber,
+            nonAssociation.secondPrisonerNumber,
+            true,
+          ).let { updatedRecord ->
+            updatedRecords.add(updatedRecord)
           }
         }
 
         if (nonAssociation.secondPrisonerNumber == oldPrisonerNumber) {
-          nonAssociationsRepository.findByFirstPrisonerNumberAndSecondPrisonerNumber(
+          val duplicateRecord = nonAssociationsRepository.findOpenBetweenPrisoners(
             firstPrisonerNumber = nonAssociation.firstPrisonerNumber,
             secondPrisonerNumber = newPrisonerNumber,
-          ).let { duplicateRecord ->
-            merge(
-              nonAssociation,
-              duplicateRecord,
-              newPrisonerNumber,
-              nonAssociation.firstPrisonerNumber,
-              false,
-            ).let { updatedRecord ->
-              updatedRecords.add(updatedRecord)
-            }
+          ).firstOrNull()
+          merge(
+            nonAssociation,
+            duplicateRecord,
+            newPrisonerNumber,
+            nonAssociation.firstPrisonerNumber,
+            false,
+          ).let { updatedRecord ->
+            updatedRecords.add(updatedRecord)
           }
         }
       }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/service/NonAssociationsMergeServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsnonassociationsapi/service/NonAssociationsMergeServiceTest.kt
@@ -35,6 +35,15 @@ class NonAssociationsMergeServiceTest {
         genNonAssociation(33, "Y1234AC", "A1234AA", now),
       ),
     )
+    // No open NAs exist for the new prisoner number with any of these third parties
+    whenever(nonAssociationsRepository.findOpenBetweenPrisoners("A1234BB", "X1234AA")).thenReturn(emptyList())
+    whenever(nonAssociationsRepository.findOpenBetweenPrisoners("A1234BB", "X1234AB")).thenReturn(emptyList())
+    whenever(nonAssociationsRepository.findOpenBetweenPrisoners("A1234BB", "X1234AC")).thenReturn(emptyList())
+    whenever(nonAssociationsRepository.findOpenBetweenPrisoners("A1234BB", "X1234AD")).thenReturn(emptyList())
+    whenever(nonAssociationsRepository.findOpenBetweenPrisoners("A1234BB", "X1234AE")).thenReturn(emptyList())
+    whenever(nonAssociationsRepository.findOpenBetweenPrisoners("Y1234AA", "A1234BB")).thenReturn(emptyList())
+    whenever(nonAssociationsRepository.findOpenBetweenPrisoners("Y1234AB", "A1234BB")).thenReturn(emptyList())
+    whenever(nonAssociationsRepository.findOpenBetweenPrisoners("Y1234AC", "A1234BB")).thenReturn(emptyList())
 
     val nonAssociationMap = service.replacePrisonerNumber("A1234AA", "A1234BB")
 
@@ -65,6 +74,8 @@ class NonAssociationsMergeServiceTest {
         genNonAssociation(5, "Y1234AC", "A1234AA", now.plusDays(2)),
       ),
     )
+    whenever(nonAssociationsRepository.findOpenBetweenPrisoners("A1234BB", "X1234AE")).thenReturn(emptyList())
+    whenever(nonAssociationsRepository.findOpenBetweenPrisoners("Y1234AA", "A1234BB")).thenReturn(emptyList())
 
     val nonAssociationMap = service.replacePrisonerNumberInDateRange(
       oldPrisonerNumber = "A1234AA",
@@ -81,5 +92,77 @@ class NonAssociationsMergeServiceTest {
         ),
       ),
     )
+  }
+
+  /**
+   * Bug: when both merge participants have an open NA with the same third party, and the new prisoner
+   * already has a closed historical NA with that third party, `findByFirstPrisonerNumberAndSecondPrisonerNumber`
+   * would return more than one row and throw IncorrectResultSizeDataAccessException.
+   *
+   * Fix: use `findOpenBetweenPrisoners` which only returns open records.
+   */
+  @Test
+  fun `when new prison has both open closed NAs with the same 3rd party`() {
+    val oldPrisoner = "A1111AA"
+    val newPrisoner = "B2222BB"
+    val thirdParty = "C3333CC"
+
+    // Old prisoner has an open NA with the third party
+    val oldOpenWithThirdParty = genNonAssociation(1, oldPrisoner, thirdParty, now)
+
+    // New prisoner has an open NA with the third party — this is the live duplicate
+    val newOpenWithThirdParty = genNonAssociation(2, newPrisoner, thirdParty, now.minusDays(5))
+
+    whenever(nonAssociationsRepository.findAllByPrisonerNumber(oldPrisoner)).thenReturn(
+      listOf(oldOpenWithThirdParty),
+    )
+    // findOpenBetweenPrisoners should return only the open record, ignoring any closed historical one
+    whenever(nonAssociationsRepository.findOpenBetweenPrisoners(newPrisoner, thirdParty)).thenReturn(
+      listOf(newOpenWithThirdParty),
+    )
+
+    val result = service.replacePrisonerNumber(oldPrisoner, newPrisoner)
+
+    // The old prisoner's NA should have been closed as a duplicate (not thrown an exception)
+    assertThat(result[MergeResult.CLOSED]).hasSize(1)
+    assertThat(result[MergeResult.CLOSED]!!.first().firstPrisonerNumber).isEqualTo(newPrisoner)
+    assertThat(result[MergeResult.CLOSED]!!.first().secondPrisonerNumber).isEqualTo(thirdParty)
+    assertThat(result[MergeResult.CLOSED]!!.first().isClosed).isTrue()
+    assertThat(result[MergeResult.MERGED]).isNull()
+  }
+
+  /**
+   * Bug: when both merge participants have an open NA with the same third party, but the new prisoner's
+   * NA is stored in the reverse direction (thirdParty, newPrisoner) rather than (newPrisoner, thirdParty),
+   * the directional lookup misses it and both NAs are left open after the merge.
+   *
+   * Fix: use `findOpenBetweenPrisoners` which checks both directions.
+   */
+  @Test
+  fun `when prisoner has an open NA stored in reverse direction with the same 3rd party detected as a duplicate`() {
+    val oldPrisoner = "A1111AA"
+    val newPrisoner = "B2222BB"
+    val thirdParty = "C3333CC"
+
+    // Old prisoner's NA: oldPrisoner is first
+    val oldOpenWithThirdParty = genNonAssociation(1, oldPrisoner, thirdParty, now)
+
+    // New prisoner's NA: stored with thirdParty as FIRST, newPrisoner as SECOND (reverse direction)
+    val newOpenWithThirdPartyReversed = genNonAssociation(2, thirdParty, newPrisoner, now.minusDays(3))
+
+    whenever(nonAssociationsRepository.findAllByPrisonerNumber(oldPrisoner)).thenReturn(
+      listOf(oldOpenWithThirdParty),
+    )
+    // findOpenBetweenPrisoners finds C-B even though we queried as (B, C)
+    whenever(nonAssociationsRepository.findOpenBetweenPrisoners(newPrisoner, thirdParty)).thenReturn(
+      listOf(newOpenWithThirdPartyReversed),
+    )
+
+    val result = service.replacePrisonerNumber(oldPrisoner, newPrisoner)
+
+    // The migrated NA should be CLOSED as a duplicate — not left MERGED/open
+    assertThat(result[MergeResult.CLOSED]).hasSize(1)
+    assertThat(result[MergeResult.CLOSED]!!.first().isClosed).isTrue()
+    assertThat(result[MergeResult.MERGED]).isNull()
   }
 }


### PR DESCRIPTION

## Background

When two prisoner records in NOMIS are identified as the same person, a merge event is raised on the SNS queue. `NonAssociationsMergeService` handles this by iterating over all non-associations (NAs) involving the old prisoner number and updating them to the new prisoner number. Where the new prisoner already has an existing NA with the same third party, the migrated record should be closed as a duplicate.

Two bugs were identified in this duplicate-detection logic.

---

## Bug 1 — `IncorrectResultSizeDataAccessException` when a closed historical record exists

### Scenario

- Prisoner **A** (old) has an open NA with third party **C**
- Prisoner **B** (new) has an open NA with third party **C**
- Prisoner **B** also has a **closed** historical NA with **C** from a previous period

### What went wrong

The duplicate lookup used `findByFirstPrisonerNumberAndSecondPrisonerNumber`, a Spring Data JPA derived query that maps to a single-result return type (`NonAssociation?`). When the database contains both an open and a closed record for the same prisoner pair, Spring Data JPA throws:

```
IncorrectResultSizeDataAccessException: Incorrect result size: expected 1, actual 2
```

The merge fails entirely and neither record is updated.

### Root cause

The method was documented with a `TODO` acknowledging this limitation:

```kotlin
// TODO: Assumes that there can only be 1 non-association given a pair of prisoner numbers.
//       In future, this will only be true for open non-associations.
fun findByFirstPrisonerNumberAndSecondPrisonerNumber(...): NonAssociation?
```

Closed historical records were not excluded from the lookup.

---

## Bug 2 — Both NAs left open when the existing NA is stored in the reverse direction

### Scenario

- Prisoner **A** (old) has an open NA stored as `(A, C)` — A is `firstPrisonerNumber`, C is `secondPrisonerNumber`
- Prisoner **B** (new) has an open NA stored as `(C, B)` — C is `firstPrisonerNumber`, B is `secondPrisonerNumber`

### What went wrong

The duplicate lookup was directional. For an `(A, C)` NA being migrated, it searched for a record where `firstPrisonerNumber = B AND secondPrisonerNumber = C`. Because the existing NA for B was stored in the reverse order `(C, B)`, the lookup returned `null` — no duplicate detected.

The service then updated `(A, C)` to `(B, C)` and marked it `MERGED` (open). The original `(C, B)` record was untouched and remained open. After the merge, both `(B, C)` and `(C, B)` existed as open NAs — a duplicate pair left in the system.

### Root cause

The direction a pair is stored depends on which prisoner was nominated as `firstPrisoner` at the time of creation — an arbitrary choice. The duplicate check assumed a fixed direction, which is not guaranteed.

---

## Fix

### `NonAssociationsRepository.kt` — new JPQL query

A new method `findOpenBetweenPrisoners(p1, p2)` was added that:

1. Only returns **open** records (fixes Bug 1 — closed historical records are ignored)
2. Checks **both storage directions** `(p1, p2)` and `(p2, p1)` (fixes Bug 2 — direction of storage is irrelevant)

```kotlin
@Query("""
    SELECT n FROM NonAssociation n
    WHERE n.isClosed = false AND (
        (n.firstPrisonerNumber = :p1 AND n.secondPrisonerNumber = :p2) OR
        (n.firstPrisonerNumber = :p2 AND n.secondPrisonerNumber = :p1)
    )
""")
fun findOpenBetweenPrisoners(@Param("p1") p1: String, @Param("p2") p2: String): List<NonAssociation>
```

Returning a `List` rather than a nullable single result also eliminates the risk of a future exception if, for any reason, multiple open records exist for the same pair.

### `NonAssociationsMergeService.kt` — use new query

Both calls to `findByFirstPrisonerNumberAndSecondPrisonerNumber` were replaced with `findOpenBetweenPrisoners(...).firstOrNull()`:

```kotlin
// Before (directional, includes closed records, single-result — throws if > 1 row)
nonAssociationsRepository.findByFirstPrisonerNumberAndSecondPrisonerNumber(
    firstPrisonerNumber = newPrisonerNumber,
    secondPrisonerNumber = nonAssociation.secondPrisonerNumber,
)

// After (bidirectional, open only, safe with multiple historical records)
nonAssociationsRepository.findOpenBetweenPrisoners(
    p1 = newPrisonerNumber,
    p2 = nonAssociation.secondPrisonerNumber,
).firstOrNull()
```

---

## Tests

### `NonAssociationsMergeServiceTest.kt`

Two regression tests were added to `NonAssociationsMergeServiceTest`:

#### Test for Bug 1
> `when new prisoner has both open and closed NAs with the same third party, only the open one is treated as a duplicate`

Verifies that when `findOpenBetweenPrisoners` returns only the open record (as it should, having excluded closed ones), the merge service correctly closes the migrated NA without throwing an exception.

#### Test for Bug 2
> `when new prisoner has an open NA stored in reverse direction with the same third party, it is still detected as a duplicate`

Verifies that when the existing NA for the new prisoner is stored as `(thirdParty, newPrisoner)` rather than `(newPrisoner, thirdParty)`, `findOpenBetweenPrisoners` still returns it and the migrated NA is correctly closed rather than left open.

The two existing tests (`can merge prisoner numbers` and `can move a booking between prisoner numbers`) were updated to mock `findOpenBetweenPrisoners` instead of the old `findByFirstPrisonerNumberAndSecondPrisonerNumber`.

---

## Files changed

| File | Change |
|------|--------|
| `src/main/kotlin/.../jpa/repository/NonAssociationsRepository.kt` | Added `findOpenBetweenPrisoners` JPQL query |
| `src/main/kotlin/.../service/NonAssociationsMergeService.kt` | Replaced directional single-result lookup with bidirectional open-only lookup |
| `src/test/kotlin/.../service/NonAssociationsMergeServiceTest.kt` | Updated mocks; added two regression tests |
