### PR TITLE
IR-1641: Enable Snyk scan

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -20,6 +20,8 @@ on:
 permissions:
   contents: read
   packages: write
+  id-token: write
+  attestations: write
 
 concurrency:
   # Only cancel in progress when on a branch - use SHA on main to ensure uniqueness.
@@ -70,6 +72,10 @@ jobs:
       additional_docker_tag: ${{ inputs.additional_docker_tag }}
       push: ${{ inputs.push || true }}
       docker_multiplatform: false
+      download_build_artifacts: true
+      generate_sbom: true
+      attach_sbom_to_registry: true
+      sign_image: true
   deploy_dev:
     name: Deploy to the development environment
     needs:

--- a/.github/workflows/security_snyk_scan.yml
+++ b/.github/workflows/security_snyk_scan.yml
@@ -6,6 +6,10 @@ on:
   #   - cron: '0 5 * * 1-5' # every weekday at 5 AM
 jobs:
   security-snyk-check:
+    permissions:
+      contents: read
+      actions: read
+      security-events: write
     name: Project security Snyk dependency check
     uses: ministryofjustice/hmpps-github-actions/.github/workflows/security_snyk_scan.yml@v2
     with:
@@ -17,5 +21,5 @@ jobs:
       slack_include_summary: true
       snyk_policy_path: '' # Optional path to a custom Snyk policy file
     secrets:
-      SNYK_TOKEN: ${{ secrets.HMPPS_SNYK_API_KEY }}
+      HMPPS_SNYK_API_KEY: ${{ secrets.HMPPS_SNYK_API_KEY }}
       HMPPS_SRE_SLACK_BOT_TOKEN: ${{ secrets.HMPPS_SRE_SLACK_BOT_TOKEN }}

--- a/.github/workflows/security_snyk_scan.yml
+++ b/.github/workflows/security_snyk_scan.yml
@@ -15,7 +15,7 @@ jobs:
       scan_type: 'image' # or 'fs'
       location: '.'
       slack_include_summary: true
-      snyk_policy_path: ''
+      snyk_policy_path: '' # Optional path to a custom Snyk policy file
     secrets:
-      SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+      SNYK_TOKEN: ${{ secrets.HMPPS_SNYK_API_KEY }}
       HMPPS_SRE_SLACK_BOT_TOKEN: ${{ secrets.HMPPS_SRE_SLACK_BOT_TOKEN }}

--- a/.github/workflows/security_snyk_scan.yml
+++ b/.github/workflows/security_snyk_scan.yml
@@ -1,0 +1,21 @@
+name: Security Snyk dependency check
+
+on:
+  workflow_dispatch:
+  # schedule:
+  #   - cron: '0 5 * * 1-5' # every weekday at 5 AM
+jobs:
+  security-snyk-check:
+    name: Project security Snyk dependency check
+    uses: ministryofjustice/hmpps-github-actions/.github/workflows/security_snyk_scan.yml@v2
+    with:
+      channel_id: ${{ vars.SECURITY_ALERTS_SLACK_CHANNEL_ID || 'NO_SLACK' }}
+      subproject: ''
+      severity: 'HIGH,CRITICAL'
+      scan_type: 'image' # or 'fs'
+      location: '.'
+      slack_include_summary: true
+      snyk_policy_path: ''
+    secrets:
+      SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+      HMPPS_SRE_SLACK_BOT_TOKEN: ${{ secrets.HMPPS_SRE_SLACK_BOT_TOKEN }}

--- a/.github/workflows/security_snyk_scan.yml
+++ b/.github/workflows/security_snyk_scan.yml
@@ -2,8 +2,8 @@ name: Security Snyk dependency check
 
 on:
   workflow_dispatch:
-  # schedule:
-  #   - cron: '0 5 * * 1-5' # every weekday at 5 AM
+  schedule:
+    - cron: '18 7 * * 1-5' # every weekday at 5 AM
 jobs:
   security-snyk-check:
     permissions:

--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["github>ministryofjustice/hmpps-renovate-config:jvm"],
-  "assigneesFromCodeOwners": true,
   "prBodyTemplate": "{{{table}}}{{{notes}}}{{{warnings}}}{{{controls}}}",
   "packageRules": [
     {
@@ -11,18 +10,11 @@
       "groupSlug": "all-gradle-minor-patch"
     },
     {
-      "matchManagers": ["gradle"],
-      "matchPackageNames": ["io.swagger.parser.v3:swagger-parser"],
+      "matchManagers": ["github-actions"],
+      "matchFileNames": ["**/.github/workflows/**/*.ya?ml"],
       "matchUpdateTypes": ["minor", "patch"],
-      "groupName": "swagger-parser",
-      "groupSlug": "swagger-parser"
-    },
-    {
-      "matchManagers": ["gradle"],
-      "matchPackageNames": ["uk.gov.justice.service.hmpps:hmpps-digital-prison-reporting-lib"],
-      "matchUpdateTypes": ["minor", "patch"],
-      "groupName": "hmpps-digital-prison-reporting-lib",
-      "groupSlug": "hmpps-digital-prison-reporting-lib"
+      "enabled": false
     }
-  ]
+  ],
+  "platformCommit": "enabled"
 }

--- a/renovate.json
+++ b/renovate.json
@@ -7,7 +7,8 @@
       "matchManagers": ["gradle"],
       "matchUpdateTypes": ["minor", "patch"],
       "groupName": "all non major Gradle dependencies",
-      "groupSlug": "all-gradle-minor-patch"
+      "groupSlug": "all-gradle-minor-patch",
+      "minimumReleaseAge": "7 days"
     },
     {
       "matchManagers": ["github-actions"],


### PR DESCRIPTION
Various security tweaks:
- enable Docker image signing
- removed Trivy scan
- added Snyk scan
- copied Renovate config from template and also
  - set `minimumReleaseAge` to `"7 days"` so we don't get updates which are too fresh
  - removed rules for DPR and swagger
